### PR TITLE
Add conditional rules for linear vs circular contigs

### DIFF
--- a/snakemake/genome_longread.smk
+++ b/snakemake/genome_longread.smk
@@ -220,7 +220,9 @@ rule polish_polca:
     input:
         "polish/polypolish/polypolish.fasta"
     output:
-        "polish/polca/polca.fasta"
+        "polish/polca/polca.fasta",
+        temp("polish/polca/polypolish.fasta.unSorted.sam"),
+        temp("polish/polca/polypolish.fasta.alignSorted.bam")
     conda:
         "../envs/masurca.yaml"
     log:


### PR DESCRIPTION
A snakemake checkpoint is used so that only circular contigs are subjected to circularization.