### PR TITLE
Bug fixes lee

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -79,4 +79,4 @@ hmmsearch_evalue: 1e-40
 gtdbtk_mode: "default"
 # EggNOG annotation sensitivity mode (using DIAMOND)
 #    Options: fast, mid-sensitive, sensitive, more-sensitive, very-sensitive, ultra-sensitive
-eggnog_sensmode: "ultra-sensitive"
+eggnog_sensmode: "sensitive"

--- a/envs/gtdbtk.yaml
+++ b/envs/gtdbtk.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - gtdbtk=2.1.1 # Remember to update VERSION_GTDB in the snakefile if the GTDB version updates
+  - gtdbtk=2.3.2 # Remember to update VERSION_GTDB in the snakefile if the GTDB version updates

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -12,7 +12,7 @@ VERSION="0.2.0-beta4"
 VERSION_POLYPOLISH="0.5.0"
 VERSION_DFAST="1.2.18"
 VERSION_EGGNOG="5.0.0" # See http://eggnog5.embl.de/#/app/downloads
-VERSION_GTDB="207" # See https://data.gtdb.ecogenomic.org/releases/
+VERSION_GTDB="214" # See https://data.gtdb.ecogenomic.org/releases/
 
 # Specify the minimum snakemake version allowable
 min_version("7.0")

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -1066,8 +1066,8 @@ rule run_gtdbtk:
     shell:
         """
         printf "{input.genome}\t{params.genome_id}\n" > {output.batchfile}
-        gtdbtk classify_wf --batchfile {output.batchfile} --out_dir {params.outdir} \
-          {params.gtdbtk_mode} --cpus {threads} --pplacer_cpus {threads} > {log} 2>&1
+        gtdbtk classify_wf --batchfile {output.batchfile} --out_dir {params.outdir} {params.gtdbtk_mode} \
+           --skip_ani_screen --cpus {threads} --pplacer_cpus {threads} > {log} 2>&1
         head -n 1 {params.outdir}/gtdbtk.*.summary.tsv | sort -u > {output.annotation}
         tail -n +2 {params.outdir}/gtdbtk.*.summary.tsv >> {output.annotation}
         """

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -12,7 +12,7 @@ VERSION="0.2.0-beta4"
 VERSION_POLYPOLISH="0.5.0"
 VERSION_DFAST="1.2.18"
 VERSION_EGGNOG="5.0.0" # See http://eggnog5.embl.de/#/app/downloads
-VERSION_GTDB="214" # See https://data.gtdb.ecogenomic.org/releases/
+VERSION_GTDB="207" # See https://data.gtdb.ecogenomic.org/releases/
 
 # Specify the minimum snakemake version allowable
 min_version("7.0")

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -80,11 +80,11 @@ rule download_hmm:
         "benchmarks/download/hmm_download.txt"
     params:
         db_dir=os.path.join(config.get("db_dir"), "hmm"),
-        url="https://pfam.xfam.org/family/" + config.get("start_hmm_pfam_id") + "/hmm"
+        url="http://pfam-legacy.xfam.org/family/" + config.get("start_hmm_pfam_id") + "/hmm"
     shell:
         """
         mkdir -p {params.db_dir}
-        wget -O {output.hmm} {params.url} 2> {log}
+        wget -O {output.hmm} --no-check-certificate {params.url} 2> {log}
         """
 
 

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -1067,7 +1067,7 @@ rule run_gtdbtk:
         """
         printf "{input.genome}\t{params.genome_id}\n" > {output.batchfile}
         gtdbtk classify_wf --batchfile {output.batchfile} --out_dir {params.outdir} {params.gtdbtk_mode} \
-           --skip_ani_screen --cpus {threads} --pplacer_cpus {threads} > {log} 2>&1
+           --mash_db {params.outdir}/{params.genome_id}_sketch.msh --cpus {threads} --pplacer_cpus {threads} > {log} 2>&1
         head -n 1 {params.outdir}/gtdbtk.*.summary.tsv | sort -u > {output.annotation}
         tail -n +2 {params.outdir}/gtdbtk.*.summary.tsv >> {output.annotation}
         """

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -384,8 +384,8 @@ rule assembly_end_repair:
 #        In particular, the format of assembly_info.txt will need to be standardized (also in assembly_end_repair).
 rule finalize_assembly:
     input:
-        assembly="assembly/end_repair/repaired.fasta",
-        info="assembly/end_repair/assembly_info.txt"
+        assembly="assembly/flye/assembly.fasta",
+        info="assembly/flye/assembly_info.txt"
     output:
         assembly="assembly/assembly.fasta",
         info="assembly/assembly_info.txt"

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -209,7 +209,7 @@ rule build_gtdb_mash_ref_database:
     input:
         os.path.join(config.get("db_dir"),"checkpoints","GTDB_" + VERSION_GTDB_COMPLETE + "_validate")
     output:
-        ref_msh_file=os.path.join(config.get("db_dir"),"Mash_GTDB_" + VERSION_GTDB_COMPLETE, 'mash', 'gtdb_ref_sketch.msh')
+        ref_msh_file=os.path.join(config.get("db_dir"),"GTDB_" + VERSION_GTDB_COMPLETE + '_mash', 'gtdb_ref_sketch.msh')
     conda:
         "../envs/gtdbtk.yaml"
     log:
@@ -1072,7 +1072,7 @@ rule run_gtdbtk:
     input:
         genome="annotation/dfast/genome.fna",
         setup_finished=os.path.join(config.get("db_dir"),"checkpoints", "GTDB_" + VERSION_GTDB_COMPLETE + "_validate"),
-        ref_genome_path_list=os.path.join(config.get("db_dir"),"GTDB_" + VERSION_GTDB_COMPLETE + '_mash', 'ref_mash_genomes.txt')
+        ref_msh_file=os.path.join(config.get("db_dir"),"GTDB_" + VERSION_GTDB_COMPLETE + '_mash', 'gtdb_ref_sketch.msh')
     output:
         batchfile=temp("annotation/gtdbtk/batchfile.tsv"),
         annotation="annotation/gtdbtk/gtdbtk.summary.tsv"

--- a/rules/rotary.smk
+++ b/rules/rotary.smk
@@ -141,7 +141,7 @@ rule download_gtdb_db:
         "benchmarks/download/gtdb_db_download.txt"
     params:
         db_dir_root=os.path.join(config.get("db_dir")),
-        initial_download_dir=os.path.join(config.get("db_dir"), "release" + VERSION_GTDB_COMPLETE),
+        initial_download_dir=os.path.join(config.get("db_dir"), "release" + VERSION_GTDB_MAIN),
         db_dir=os.path.join(config.get("db_dir"), "GTDB_" + VERSION_GTDB_COMPLETE),
         url="https://data.gtdb.ecogenomic.org/releases/release" + VERSION_GTDB_MAIN + "/" + VERSION_GTDB_COMPLETE + "/auxillary_files/gtdbtk_r" + VERSION_GTDB_MAIN + "_data.tar.gz"
     shell:


### PR DESCRIPTION
fixes to various bugs found when Lee installed and ran Rotary. These include 

- Fixing inability to download PFAM hmms (temporary)
- Updating GTDBtk
- Adding a step to pre-built a mash reference database for GTDBtk.
- Modified the GTDB downloader to download a specific subversion of GTDB.