### PR TITLE
Bug fixes env pathing and file extentions

### DIFF
--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -96,7 +96,7 @@ def main():
                                                                                                    run_file_presences)))
     existing_message = f'Existing run configuration files {run_files} in the output directory.'
 
-    conda_env_directory = os.path.join(output_dir_path, 'conda_env')
+    conda_env_directory = os.path.join(database_dir_path, 'rotary_conda_env')
     os.makedirs(conda_env_directory, exist_ok=True)
 
     # Select the sub-command to run.

--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -14,7 +14,7 @@ import sys
 import psutil
 from ruamel.yaml import YAML
 
-from rotary.sample import SequencingFile, Sample
+from rotary.sample import SequencingFile, Sample, is_fastq_file
 from rotary.utils import check_for_files, get_cli_arg_path
 
 yaml = YAML()
@@ -197,10 +197,10 @@ def init(args, config, output_dir_path):
     input_path = get_cli_arg_path(args, 'input_dir')
     fastq_files = []
 
-    for file in os.listdir(input_path):
-        if 'fastq' in file:
-            file = SequencingFile(file_path=(os.path.join(input_path, file)))
-            fastq_files.append(file)
+    for file_path in os.listdir(input_path):
+        filename = os.path.basename(file_path)
+        if is_fastq_file(filename):
+            fastq_files.append(SequencingFile(file_path=os.path.join(input_path, file_path)))
 
     samples_files = {}
     for file in fastq_files:

--- a/rotary/sample.py
+++ b/rotary/sample.py
@@ -20,9 +20,7 @@ class SequencingFile(object):
         self.path = file_path
         self.name = os.path.basename(self.path)
 
-        file_extension = os.path.splitext(self.name)[1]
-
-        if 'fastq' not in file_extension and 'fq' not in file_extension:
+        if not is_fastq_file(self.name):
             raise ValueError(f'{self.name} is not a fastq file.')
 
         if '_' in self.name:
@@ -38,6 +36,8 @@ class SequencingFile(object):
             self.r_value = r_value[0].upper()
         else:
             self.r_value = None
+
+
 
 
 class Sample(object):
@@ -92,3 +92,18 @@ class Sample(object):
         :return: Returns a list containing the sample identifier and the paths to sample's the input files.
         """
         return [self.identifier, self.long_read_path, self.short_read_left_path, self.short_read_right_path]
+
+def is_fastq_file(file_name):
+    """
+    Determines if file is a fastq file based in its extension.
+    :param file_name: The name of the file.
+    :return: True if the file contains 'fastq' or 'fq'.
+    """
+    file_extension = file_name.split(os.path.extsep, 1)[1]
+
+    if 'fastq' in file_extension or 'fq' in file_extension:
+        is_fastq = True
+    else:
+        is_fastq = False
+
+    return is_fastq


### PR DESCRIPTION
Add fixes that address https://github.com/jmtsuji/rotary/issues/61 and https://github.com/jmtsuji/rotary/issues/62

1. Moved the rotary conda environment directory to the database directory.
2. Fastq file extension checks are now compatible with fastq.gz files.
3. Check for both fq and fastq in rotary init.
4.  Created unified function for checking if a file is a fastq file.