### PR TITLE
Short read improvements

### DIFF
--- a/rotary/config.yaml
+++ b/rotary/config.yaml
@@ -16,6 +16,7 @@ minlength: 1000
 minavgquality: 13
 
 ## Short read QC
+
 ## Adapter trimming
 # Perform adapter trimming from the right side of reads? Identifies adapters using both a built-in database.
 perform_adapter_trimming: "True"
@@ -28,6 +29,7 @@ minimum_detectable_adapter_length_on_read_end: 6
 overlap_based_trimming: "True"
 # Minimum read length after adapter trimming (otherwise is discarded)
 minimum_read_length_adapter_trim: 10
+
 ## Quality trimming
 # Whether to perform quality trimming on the right ("r") side of each read or on both the left and right ("rl") sides
 #  Otherwise, specify "f" to skip quality trimming altogether.
@@ -38,9 +40,8 @@ quality_trim_score_cutoff: 20
 minimum_average_quality_score_post_trim: 20
 # Minimum read length after quality trimming (otherwise is discarded)
 minimum_read_length_quality_trim: 10
+
 ## Contaminant filtration
-# Search for and remove reads that match contaminant reference sequences?
-perform_contaminant_filtration: "True"
 # K-mer length for filtering contaminants
 contamination_filter_kmer_length: 31
 # NCBI genome assembly accessions to use for filtering contaminants from short read data.

--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -523,8 +523,10 @@ rule short_read_contamination_filter:
     input:
         short_r1 = "{sample}/qc/short/{sample}_quality_trim_R1.fastq.gz",
         short_r2 = "{sample}/qc/short/{sample}_quality_trim_R2.fastq.gz",
-        ncbi_contamination_references = expand(os.path.join(DB_DIR_PATH, 'contamination_references', 'ncbi', '{accession}.fna.gz'), accession=CONTAMINATION_NCBI_ACCESSIONS),
-        custom_contamination_references = expand(os.path.join(DB_DIR_PATH, 'contamination_references', 'custom', '{contaminant_name}.fna.gz'), contaminant_name=CUSTOM_CONTAMINATION_FILE_NAMES)
+        ncbi_contamination_references = expand(os.path.join(DB_DIR_PATH, 'contamination_references', 'ncbi',
+            '{accession}.fna.gz'), accession=CONTAMINATION_NCBI_ACCESSIONS),
+        custom_contamination_references = expand(os.path.join(DB_DIR_PATH, 'contamination_references', 'custom',
+            '{contaminant_name}.fna.gz'), contaminant_name=CUSTOM_CONTAMINATION_FILE_NAMES)
     output:
         short_r1 = temp("{sample}/qc/short/{sample}_filter_R1.fastq.gz"),
         short_r2 = temp("{sample}/qc/short/{sample}_filter_R2.fastq.gz"),
@@ -538,6 +540,8 @@ rule short_read_contamination_filter:
         "{sample}/benchmarks/qc/short/short_read_contamination_filter.benchmark.txt"
     params:
         contamination_filter_kmer_length = config.get("contamination_filter_kmer_length"),
+        contamination_references = lambda wildcards, input: ','.join(input.ncbi_contamination_references +
+                                                                     input.custom_contamination_references)
     threads:
         config.get("threads", 1)
     resources:
@@ -545,7 +549,7 @@ rule short_read_contamination_filter:
     shell:
         """
         bbduk.sh -Xmx{resources.mem}g threads={threads} in={input.short_r1} in2={input.short_r2} \
-          ref={input.ncbi_contamination_references} {input.custom_contamination_references} out={output.short_r1} out2={output.short_r2} \
+          ref={params.contamination_references} out={output.short_r1} out2={output.short_r2} \
           stats={output.filter_stats} qhist={output.quality_histogram} \
           k={params.contamination_filter_kmer_length} ktrim=f rcomp=t \
           overwrite=t interleaved=f qin=33 pigz=t unpigz=t \

--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -558,8 +558,8 @@ rule finalize_qc_short:
     The conditional statements in this rule control whether or not contaminant filtration is performed.
     """
     input:
-        short_r1 = "{sample}/qc/short/{sample}_filter_R1.fastq.gz" if CONTAMINANT_REFERENCE_GENOMES != False else "{sample}/qc/short/{sample}_quality_trim_R1.fastq.gz",
-        short_r2 = "{sample}/qc/short/{sample}_filter_R2.fastq.gz" if CONTAMINANT_REFERENCE_GENOMES != False else "{sample}/qc/short/{sample}_quality_trim_R2.fastq.gz"
+        short_r1 = "{sample}/qc/short/{sample}_filter_R1.fastq.gz" if CONTAMINANT_REFERENCE_GENOMES == True else "{sample}/qc/short/{sample}_quality_trim_R1.fastq.gz",
+        short_r2 = "{sample}/qc/short/{sample}_filter_R2.fastq.gz" if CONTAMINANT_REFERENCE_GENOMES == True else "{sample}/qc/short/{sample}_quality_trim_R2.fastq.gz"
     output:
         short_r1 = "{sample}/qc/short/{sample}_qc_R1.fastq.gz",
         short_r2 = "{sample}/qc/short/{sample}_qc_R2.fastq.gz"

--- a/rotary/utils.py
+++ b/rotary/utils.py
@@ -100,28 +100,3 @@ def symlink_or_compress(in_file_path, out_file_path):
         os.symlink(in_file_path, out_file_path)
     else:
         gzip_file(in_file_path, out_file_path)
-
-
-def get_contamination_reference_file_paths(ncbi_accessions: list, db_path: str):
-    """
-    Returns a list of file paths for contamination references based on NCBI genome assembly accessions
-
-    :param ncbi_accessions: value of config.get('contamination_references_ncbi_accessions'); should be a list
-    :param db_path: path to the rotary database folder
-    :return: list of file paths for the contamination reference genomes
-    """
-
-    contamination_reference_paths = []
-
-    if isinstance(ncbi_accessions, list):
-        for ncbi_accession in ncbi_accessions:
-            contamination_reference_paths.append(os.path.join(db_path, 'contamination_references',
-                                                              f'{ncbi_accession}.fna.gz'))
-
-    else:
-        raise TypeError(f'Contaminant genome accessions must be in a list, but you provided type '
-                        f'{type(ncbi_accessions)}. Try editing the config file and make sure that '
-                        f'contamination_references_ncbi_accessions is a list like '
-                        '["GCF_000819615.1"] or ["GCF_000819615.1", "GCF_000001405.40"], not just "GCF_000819615.1".')
-
-    return contamination_reference_paths


### PR DESCRIPTION
- removed perform_contaminant_filtration config parameter. Users can now leave both lists empty to skip filtering.
- removed get_contamination_reference_file_paths as it is no longer necessary.
- add code for symlinking custom file paths to the database directory.