### PR TITLE
delete requirement to check for other polca files.

### DIFF
--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -800,22 +800,21 @@ rule polish_polca:
         qc_short_r2 = "{sample}/qc/{sample}_qc_R2.fastq.gz",
         polished = "{sample}/polish/polypolish/{sample}_polypolish.fasta"
     output:
-        polca_output = "{sample}/polish/polca/{sample}_polca.fasta"
+        polca_output = temp("{sample}/polish/polca/{sample}_polca.fasta"),
+        outdir = temp(directory("{sample}/polish/polca"))
     conda:
         "../envs/masurca.yaml"
     log:
         "{sample}/logs/polish/polca.log"
     benchmark:
         "{sample}/benchmarks/polish/polca.txt"
-    params:
-        outdir="{sample}/polish/polca"
     threads:
         config.get("threads",1)
     resources:
         mem=config.get("memory")
     shell:
         """
-        cd {params.outdir}
+        cd {output.outdir}
         polca.sh -a ../../../{input.polished} -r "../../../{input.qc_short_r1} ../../../{input.qc_short_r2}" -t {threads} -m {resources.mem}G > ../../../{log} 2>&1
         ln -s "{wildcards.sample}_polypolish.fasta.PolcaCorrected.fa" "{wildcards.sample}_polca.fasta"
         cd ../../../

--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -800,9 +800,7 @@ rule polish_polca:
         qc_short_r2 = "{sample}/qc/{sample}_qc_R2.fastq.gz",
         polished = "{sample}/polish/polypolish/{sample}_polypolish.fasta"
     output:
-        polca_output = "{sample}/polish/polca/{sample}_polca.fasta",
-        polypolish_sam = temp("{sample}/polish/polca/{sample}_polypolish.fasta.unSorted.sam"),
-        polypolish_bam = temp("{sample}/polish/polca/{sample}_polypolish.fasta.alignSorted.bam")
+        polca_output = "{sample}/polish/polca/{sample}_polca.fasta"
     conda:
         "../envs/masurca.yaml"
     log:


### PR DESCRIPTION
I ran into this error where Polca wouldn't find the files:

- {sample}_polypolish.fasta.unSorted.sam"
- {sample}_polypolish.fasta.alignSorted.bam"

The polca folder has the other files created by the polca run but not these. Does the newer version of Polca not produce these files? Either way, none of these files are used by the follow-on steps, so I removed them from the required outputs.