### PR TITLE
Install Polypolish via Conda

### DIFF
--- a/rotary/envs/polypolish.yaml
+++ b/rotary/envs/polypolish.yaml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - polypolish=0.6.0
+  - bwa=0.7.17
+  - seqtk=1.3

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -98,9 +98,7 @@ rule polish_polypolish:
         printf "\n\n### Polypolish ###\n" >> {log}
         polypolish polish --debug {output.debug} {input.contigs}  \
           {output.mapping_clean_r1} {output.mapping_clean_r2} 2>> {log} | 
-          seqtk seq -A -l 0 | 
-          awk \'{{ if ($0 ~ /^>/) {{ gsub("_polypolish", ""); print }} else {{ print }} }}\' | 
-          seqtk seq -l 60 > {output.polished} 2>> {log}
+          seqtk seq -A -C -l 60 > {output.polished} 2>> {log}
 
         head -n 1 {output.debug} > {output.debug_stats}
         grep changed {output.debug} >> {output.debug_stats}


### PR DESCRIPTION
I noticed that we were doing a manual install of poly-polish while working on creating a unified download rule. Decided to simplify the code.

- Create a new conda environment to install polypolish.
  - Move to polypolish 0.6.0
- Remove the rule for installing polypolish.
- Simplify rule `polish_polypolish`:
  - Remove inputs to polypolish scripts.
  - Call polypolish sub commands directly.