### PR TITLE
Improve read mapping rules

### DIFF
--- a/rotary/config.yaml
+++ b/rotary/config.yaml
@@ -117,3 +117,5 @@ gtdbtk_mode: "default"
 eggnog_sensmode: "sensitive"
 # The search tool that emapper.py should use (diamond or mmseqs).
 eggnog_search_tool: 'mmseqs'
+# Keep final coverage read mapping BAM files for further analysis.
+keep_final_coverage_bam_files: 'False'

--- a/rotary/envs/mapping.yaml
+++ b/rotary/envs/mapping.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.9.7
   - samtools=1.15
-  - bwa=0.7.17
+  - bwa-mem2=2.2.1
   - seqtk=1.3
   - prodigal=2.6.3
   - hmmer=3.3.2

--- a/rotary/envs/masurca.yaml
+++ b/rotary/envs/masurca.yaml
@@ -4,4 +4,4 @@ channels:
   - defaults
 dependencies:
   - masurca=4.0.8
-  - bwa=0.7.17
+  - bwa-mem2=2.2.1

--- a/rotary/envs/polypolish.yaml
+++ b/rotary/envs/polypolish.yaml
@@ -4,5 +4,4 @@ channels:
   - defaults
 dependencies:
   - polypolish=0.6.0
-  - bwa=0.7.17
   - seqtk=1.3

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -311,8 +311,8 @@ if POLISH_WITH_SHORT_READS == True:
             mem=int(config.get("memory") / config.get("threads",1))
         shell:
             """
-            bwa index {input.dfast_genome} 2> {log}
-            bwa mem -t {threads} {input.dfast_genome} {input.qc_short_r1} {input.qc_short_r2} 2>> {log} | \
+            bwa-mem2 index {input.dfast_genome} 2> {log}
+            bwa-mem2 mem -t {threads} {input.dfast_genome} {input.qc_short_r1} {input.qc_short_r2} 2>> {log} | \
               samtools view -b -@ {threads} 2>> {log} | \
               samtools sort -@ {threads} -m {resources.mem}G 2>> {log} \
               > {output.mapping}

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -11,6 +11,11 @@ VERSION_GTDB_MAIN=VERSION_GTDB_COMPLETE.split('.')[0] # Remove subversion
 
 DB_DIR_PATH = config.get('db_dir')
 
+if str(config.get('keep_final_coverage_bam_files')).lower() == 'true':
+    KEEP_BAM_FILES = True
+else:
+    KEEP_BAM_FILES = False
+
 # SAMPLE_NAMES, and POLISH_WITH_SHORT_READS are instantiated in rotary.smk
 
 rule download_dfast_db:
@@ -294,7 +299,7 @@ if POLISH_WITH_SHORT_READS == True:
             qc_short_r2="{sample}/qc/{sample}_qc_R2.fastq.gz",
             dfast_genome="{sample}/annotation/dfast/{sample}_genome.fna"
         output:
-            mapping=temp("{sample}/annotation/coverage/{sample}_short_read.bam"),
+            mapping="{sample}/annotation/coverage/{sample}_short_read.bam" if KEEP_BAM_FILES else temp("{sample}/annotation/coverage/{sample}_short_read.bam"),
             index=temp("{sample}/annotation/coverage/{sample}_short_read.bam.bai"),
             coverage="{sample}/annotation/coverage/{sample}_short_read_coverage.tsv",
             read_mapping_files= temp(multiext("{sample}/annotation/dfast/{sample}_genome.fna",
@@ -326,7 +331,7 @@ rule calculate_final_long_read_coverage:
         contigs="{sample}/annotation/dfast/{sample}_genome.fna",
         qc_long_reads="{sample}/qc/{sample}_qc_long.fastq.gz"
     output:
-        mapping=temp("{sample}/annotation/coverage/{sample}_long_read.bam"),
+        mapping="{sample}/annotation/coverage/{sample}_long_read.bam" if KEEP_BAM_FILES else temp("{sample}/annotation/coverage/{sample}_long_read.bam"),
         index=temp("{sample}/annotation/coverage/{sample}_long_read.bam.bai"),
         coverage="{sample}/annotation/coverage/{sample}_long_read_coverage.tsv"
     conda:

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -297,8 +297,8 @@ if POLISH_WITH_SHORT_READS == True:
             mapping=temp("{sample}/annotation/coverage/{sample}_short_read.bam"),
             index=temp("{sample}/annotation/coverage/{sample}_short_read.bam.bai"),
             coverage="{sample}/annotation/coverage/{sample}_short_read_coverage.tsv",
-            read_mapping_files= temp(expand("{{sample}}/annotation/dfast/{{sample}}_genome.fna.{ext}",
-                ext=READ_MAPPING_FILE_EXTENSIONS)) # Variable declared in polish.smk
+            read_mapping_files= temp(multiext("{sample}/annotation/dfast/{sample}_genome.fna",
+                *READ_MAPPING_FILE_EXTENSIONS)) # Variable declared in polish.smk
         conda:
             "../envs/mapping.yaml"
         log:

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -150,10 +150,18 @@ rule polish_polca:
         mem=config.get("memory")
     shell:
         """
+        printf "\n\n### Replace BWA with bwa-mem2 ###\n" >> {log}
+        bwa_mem2_path=$(which bwa-mem2)
+        bwa_mem2_dir=$(dirname $bwa_mem2_path)
+        ln -s $bwa_mem2_path $bwa_mem2_dir/bwa
+        
+        printf "\n\n### Run POLCA ###\n" >> {log}
         cd {params.outdir}
         polca.sh -a ../../../{input.polished} -r "../../../{input.qc_short_r1} ../../../{input.qc_short_r2}" -t {threads} -m {resources.mem}G > ../../../{log} 2>&1
         ln -s "{wildcards.sample}_polypolish.fasta.PolcaCorrected.fa" "{wildcards.sample}_polca.fasta"
         cd ../../../
+        
+        printf "\n\n### Done. ###\n"
         """
 
 

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -155,7 +155,7 @@ rule polish_polca:
         if [ -z "${{bwa_path}}" ]; then
             bwa_mem2_path="$(which bwa-mem2)"
             bwa_mem2_dir="$(dirname "${{bwa_mem2_path}}")"
-            ln -s "${{bwa_mem2_path}}" "${{bwa_mem2_dir/bwa}}"
+            ln -s "${{bwa_mem2_path}}" "${{bwa_mem2_dir}}/bwa"
         
             for variant in avx avx2 avx512bw sse41 sse42; do
                 bwa_mem2_variant_path="$(which bwa-mem2.${{variant}})"

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -151,14 +151,17 @@ rule polish_polca:
     shell:
         """
         printf "\n\n### Replace bwa with bwa-mem2 ###\n" >> {log}
-        bwa_mem2_path=$(which bwa-mem2)
-        bwa_mem2_dir=$(dirname $bwa_mem2_path)
-        ln -s $bwa_mem2_path $bwa_mem2_dir/bwa
+        bwa_path=$(which bwa)
+        if [ -z "$bwa_path" ]; then
+            bwa_mem2_path=$(which bwa-mem2)
+            bwa_mem2_dir=$(dirname $bwa_mem2_path)
+            ln -s $bwa_mem2_path $bwa_mem2_dir/bwa
         
-        for variant in avx avx2 avx512bw sse41 sse42; do
-            bwa_mem2_variant_path=$(which bwa-mem2.$variant)
-            ln -s bwa_mem2_variant_path $bwa_mem2_dir/bwa.$variant
-        done
+            for variant in avx avx2 avx512bw sse41 sse42; do
+                bwa_mem2_variant_path=$(which bwa-mem2.$variant)
+                ln -s $bwa_mem2_variant_path $bwa_mem2_dir/bwa.$variant
+            done
+        fi
         
         printf "\n\n### Run POLCA ###\n" >> {log}
         cd {params.outdir}

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -150,16 +150,16 @@ rule polish_polca:
         mem=config.get("memory")
     shell:
         """
-        printf "\n\n### Replace bwa with bwa-mem2 ###\n" >> {log}
-        bwa_path=$(which bwa)
-        if [ -z "$bwa_path" ]; then
-            bwa_mem2_path=$(which bwa-mem2)
-            bwa_mem2_dir=$(dirname $bwa_mem2_path)
-            ln -s $bwa_mem2_path $bwa_mem2_dir/bwa
+        printf "### Replace bwa with bwa-mem2 ###\n" >> {log}
+        bwa_path="$(which bwa)"
+        if [ -z "${{bwa_path}}" ]; then
+            bwa_mem2_path="$(which bwa-mem2)"
+            bwa_mem2_dir="$(dirname "${{bwa_mem2_path}}")"
+            ln -s "${{bwa_mem2_path}}" "${{bwa_mem2_dir/bwa}}"
         
             for variant in avx avx2 avx512bw sse41 sse42; do
-                bwa_mem2_variant_path=$(which bwa-mem2.$variant)
-                ln -s $bwa_mem2_variant_path $bwa_mem2_dir/bwa.$variant
+                bwa_mem2_variant_path="$(which bwa-mem2.${{variant}})"
+                ln -s "${{bwa_mem2_variant_path}}" "${{bwa_mem2_dir}}/bwa.${{variant}}"
             done
         fi
         

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -9,7 +9,7 @@ import pandas as pd
 
 DB_DIR_PATH = config.get('db_dir')
 
-READ_MAPPING_FILE_EXTENSIONS = ['amb', 'ann', 'bwt', 'pac', 'sa']
+READ_MAPPING_FILE_EXTENSIONS = ['.amb', '.ann', '.bwt', '.pac', '.sa']
 
 # SAMPLE_NAMES and POLISH_WITH_SHORT_READS are instantiated in rotary.smk
 
@@ -30,7 +30,7 @@ rule polish_medaka:
     output:
         dir=directory("{sample}/{step}/medaka"),
         contigs="{sample}/{step}/medaka/{sample}_consensus.fasta",
-        calls_to_draft=temp(expand("{{sample}}/{{step}}/medaka/calls_to_draft.{ext}", ext=['bam', 'bam.bai'])),
+        calls_to_draft=temp(multiext("{sample}/{step}/medaka/calls_to_draft", '.bam', '.bam.bai')),
         consensus_probs=temp("{sample}/{step}/medaka/consensus_probs.hdf")
     conda:
         "../envs/medaka.yaml"
@@ -68,8 +68,8 @@ rule map_short_reads_for_polishing:
     output:
         mapping_r1 = temp("{sample}/{step}/polypolish/{sample}_R1.sam"),
         mapping_r2 = temp("{sample}/{step}/polypolish/{sample}_R2.sam"),
-        read_mapping_files= temp(expand("{{sample}}/{{step}}/polypolish/input/{{sample}}_input.fasta.{ext}",
-            ext=READ_MAPPING_FILE_EXTENSIONS))
+        read_mapping_files= temp(multiext("{sample}/{step}/polypolish/input/{sample}_input.fasta",
+            *READ_MAPPING_FILE_EXTENSIONS))
     conda:
         "../envs/mapping.yaml"
     log:
@@ -132,8 +132,8 @@ rule polish_polca:
         polca_output = temp("{sample}/polish/polca/{sample}_polca.fasta"),
         polypolish_sam = temp("{sample}/polish/polca/{sample}_polypolish.fasta.unSorted.sam"),
         polypolish_bam = temp("{sample}/polish/polca/{sample}_polypolish.fasta.alignSorted.bam"),
-        read_mapping_files= temp(expand("{{sample}}/polish/polca/{{sample}}_polypolish.fasta.bwa.{ext}",
-            ext=READ_MAPPING_FILE_EXTENSIONS)),
+        read_mapping_files= temp(multiext("{sample}/polish/polca/{sample}_polypolish.fasta.bwa",
+            *READ_MAPPING_FILE_EXTENSIONS)),
         # Add polca directory to output, so it is deleted on rerun. It was causing an error otherwise.
         polca_directory = directory("{sample}/polish/polca/")
     conda:
@@ -185,8 +185,8 @@ if (POLISH_WITH_SHORT_READS == True) & \
             mapping=temp("{sample}/polish/cov_filter/{sample}_short_read.bam"),
             mapping_index=temp("{sample}/polish/cov_filter/{sample}_short_read.bam.bai"),
             coverage="{sample}/polish/cov_filter/{sample}_short_read_coverage.tsv",
-            read_mapping_files= temp(expand("{{sample}}/polish/cov_filter/{{sample}}_pre_filtered.fasta.{ext}", 
-                ext=READ_MAPPING_FILE_EXTENSIONS))
+            read_mapping_files= temp(multiext("{sample}/polish/cov_filter/{sample}_pre_filtered.fasta",
+                *READ_MAPPING_FILE_EXTENSIONS))
         conda:
             "../envs/mapping.yaml"
         log:

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -151,10 +151,13 @@ rule polish_polca:
     shell:
         """
         printf "\n\n### Replace bwa with bwa-mem2 ###\n" >> {log}
+        bwa_mem2_path=$(which bwa-mem2)
+        bwa_mem2_dir=$(dirname $bwa_mem2_path)
+        ln -s $bwa_mem2_path $bwa_mem2_dir/bwa
+        
         for variant in avx avx2 avx512bw sse41 sse42; do
-            bwa_mem2_path=$(which bwa-mem2.$variant)
-            bwa_mem2_dir=$(dirname $bwa_mem2_path)
-            ln -s $bwa_mem2_path $bwa_mem2_dir/bwa.$variant
+            bwa_mem2_variant_path=$(which bwa-mem2.$variant)
+            ln -s bwa_mem2_variant_path $bwa_mem2_dir/bwa.$variant
         done
         
         printf "\n\n### Run POLCA ###\n" >> {log}

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -104,8 +104,7 @@ rule polish_polypolish:
         "{sample}/logs/{step}/polypolish.log"
     benchmark:
         "{sample}/benchmarks/{step}/polypolish.txt"
-    threads:
-        config.get("threads", 1)
+    threads: 1
     shell:
         """
         printf "\n\n### Polypolish insert filter ###\n" >> {log}

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -9,7 +9,7 @@ import pandas as pd
 
 DB_DIR_PATH = config.get('db_dir')
 
-READ_MAPPING_FILE_EXTENSIONS = ['.amb', '.ann', '.bwt', '.pac', '.sa']
+READ_MAPPING_FILE_EXTENSIONS = ['.0123', '.amb', '.ann', '.bwt.2bit.64', '.pac']
 
 # SAMPLE_NAMES and POLISH_WITH_SHORT_READS are instantiated in rotary.smk
 

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -104,7 +104,6 @@ rule polish_polypolish:
         "{sample}/logs/{step}/polypolish.log"
     benchmark:
         "{sample}/benchmarks/{step}/polypolish.txt"
-    threads: 1
     shell:
         """
         printf "\n\n### Polypolish insert filter ###\n" >> {log}

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -151,9 +151,11 @@ rule polish_polca:
     shell:
         """
         printf "\n\n### Replace bwa with bwa-mem2 ###\n" >> {log}
-        bwa_mem2_path=$(which bwa-mem2)
-        bwa_mem2_dir=$(dirname $bwa_mem2_path)
-        ln -s $bwa_mem2_path $bwa_mem2_dir/bwa
+        for variant in avx avx2 avx512bw sse41 sse42; do
+            bwa_mem2_path=$(which bwa-mem2.$variant)
+            bwa_mem2_dir=$(dirname $bwa_mem2_path)
+            ln -s $bwa_mem2_path $bwa_mem2_dir/bwa.$variant
+        done
         
         printf "\n\n### Run POLCA ###\n" >> {log}
         cd {params.outdir}

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -150,7 +150,7 @@ rule polish_polca:
         mem=config.get("memory")
     shell:
         """
-        printf "\n\n### Replace BWA with bwa-mem2 ###\n" >> {log}
+        printf "\n\n### Replace bwa with bwa-mem2 ###\n" >> {log}
         bwa_mem2_path=$(which bwa-mem2)
         bwa_mem2_dir=$(dirname $bwa_mem2_path)
         ln -s $bwa_mem2_path $bwa_mem2_dir/bwa

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -81,9 +81,9 @@ rule map_short_reads_for_polishing:
     shell:
         """
         printf "\n\n### Read mapping ###\n" > {log}
-        bwa index {input.contigs} 2>> {log}
-        bwa mem -t {threads} -a {input.contigs} {input.qc_short_r1} > {output.mapping_r1} 2>> {log}
-        bwa mem -t {threads} -a {input.contigs} {input.qc_short_r2} > {output.mapping_r2} 2>> {log}
+        bwa-mem2 index {input.contigs} 2>> {log}
+        bwa-mem2 mem -t {threads} -a {input.contigs} {input.qc_short_r1} > {output.mapping_r1} 2>> {log}
+        bwa-mem2 mem -t {threads} -a {input.contigs} {input.qc_short_r2} > {output.mapping_r2} 2>> {log}
         printf "\n\n### Done. ###\n"
         """
 
@@ -200,8 +200,8 @@ if (POLISH_WITH_SHORT_READS == True) & \
         shell:
             """
             # Note that -F 4 removes unmapped reads
-            bwa index {input.contigs} 2> {log}
-            bwa mem -t {threads} {input.contigs} {input.qc_short_r1} {input.qc_short_r2} 2>> {log} | \
+            bwa-mem2 index {input.contigs} 2> {log}
+            bwa-mem2 mem -t {threads} {input.contigs} {input.qc_short_r1} {input.qc_short_r2} 2>> {log} | \
               samtools view -b -F 4 -@ {threads} 2>> {log} | \
               samtools sort -@ {threads} -m {resources.mem}G 2>> {log} \
               > {output.mapping}


### PR DESCRIPTION
- pull read mapping code out of rule `polish_polypolish` and move it to a new rule.
- utilize the `multiext()` function for removing read mapping index files (improved readability and caching).
- move from `bwa` to `bwa-mem2`, the latest `bwa` mapping algorithm (faster and much smaller index on disk)
- trick `polca.sh` into using `bwa-mem2` by symlinking `bwa-mem2` to `bwa`.
- add config flag to keep read mapping bam files used final read coverage statistics.