### PR TITLE
Fix coverage summary

### DIFF
--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -16,8 +16,7 @@ rule assembly_flye:
         consensus_dir=temp(directory("{sample}/assembly/flye/10-consensus")),
         repeat_dir=temp(directory("{sample}/assembly/flye/20-repeat")),
         contigger_dir=temp(directory("{sample}/assembly/flye/30-contigger")),
-        polishing_dir=temp(directory("{sample}/assembly/flye/40-polishing")),
-
+        polishing_dir=temp(directory("{sample}/assembly/flye/40-polishing")) if config.get("flye_polishing_rounds") > 0 else []
     conda:
         "../envs/assembly_flye.yaml"
     log:
@@ -34,7 +33,7 @@ rule assembly_flye:
     shell:
         """
         flye --{params.input_mode} {input} {params.read_error} --out-dir {output.output_dir} {params.meta_mode} \
-          --iterations {params.polishing_rounds} -t {threads} > {log} 2>&1 
+          --iterations {params.polishing_rounds} -t {threads} > {log} 2>&1
         mv {output.output_dir}/assembly.fasta {output.assembly} 
         mv {output.output_dir}/assembly_info.txt {output.info} 
         """

--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -37,8 +37,8 @@ checkpoint split_circular_and_linear_contigs:
     output:
         directory("{sample}/circularize/filter/lists")
     run:
-        contig_info = pd.read_csv(input,sep='\t')
-        contig_info_filtered = contig_info[contig_info['pass_coverage_filter'] == True]
+        contig_info = pd.read_csv(input, sep='\t')
+        contig_info_filtered = contig_info[contig_info['pass_coverage_filter'] == 'Y']
 
         circular_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'Y']
         linear_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'N']

--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -37,7 +37,7 @@ checkpoint split_circular_and_linear_contigs:
     output:
         directory("{sample}/circularize/filter/lists")
     run:
-        contig_info = pd.read_csv(input, sep='\t')
+        contig_info = pd.read_csv(input[0], sep='\t')
         contig_info_filtered = contig_info[contig_info['pass_coverage_filter'] == 'Y']
 
         circular_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'Y']

--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -33,18 +33,15 @@ rule download_hmm:
 # Based on clustering tutorial at https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html (accessed 2022.3.31)
 checkpoint split_circular_and_linear_contigs:
     input:
-        assembly_stats="{sample}/assembly/{sample}_circular_info.tsv",
-        filter_list="{sample}/polish/cov_filter/{sample}_filtered_contigs.list"
+        "{sample}/polish/{sample}_contig_info.tsv"
     output:
         directory("{sample}/circularize/filter/lists")
     run:
-        coverage_filtered_contigs = pd.read_csv(input.filter_list,header=None)[0]
+        contig_info = pd.read_csv(input,sep='\t')
+        contig_info_filtered = contig_info[contig_info['pass_coverage_filter'] == True]
 
-        assembly_info = pd.read_csv(input.assembly_stats,sep='\t')
-        assembly_info_filtered = assembly_info[assembly_info['contig'].isin(coverage_filtered_contigs)]
-
-        circular_contigs = assembly_info_filtered[assembly_info_filtered['circular'] == 'Y']
-        linear_contigs = assembly_info_filtered[assembly_info_filtered['circular'] == 'N']
+        circular_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'Y']
+        linear_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'N']
 
         os.makedirs(output[0],exist_ok=True)
 

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -308,11 +308,15 @@ else:
                 """
                 coverage_data = pd.read_csv(coverage_file,sep='\t')
 
+                # Set to zero if the user did not specify a filtration threshold
+                mean_depth = 0 if mean_depth == "None" else mean_depth
+                evenness = 0 if evenness == "None" else evenness
+
                 coverage_filtered = coverage_data[ \
                     (coverage_data['meandepth'] >= mean_depth) & \
                     (coverage_data['coverage'] >= evenness)]
 
-                return (coverage_filtered['#rname'])
+                return coverage_filtered['#rname']
 
 
             coverage_info_filepaths = list(input.coverage_info)
@@ -345,20 +349,20 @@ else:
                 set1 = set(filter_coverage_data(coverage_info_filepaths[0],params.meandepth_long,params.evenness_long))
                 set2 = set(filter_coverage_data(coverage_info_filepaths[1],params.meandepth_short,params.evenness_short))
 
-                contigs = pd.Series(set1.union(set2))
+                contigs = pd.Series(list(set1.intersection(set2)))
 
             elif len(coverage_info_filepaths) == 0:
                 sys.exit("No coverage files detected in 'polish/cov_filter'")
 
             else:
-                sys.exit("More than 2 coverage files detected in 'polish/cov_filter'.")
+                sys.exit(f"More than 2 coverage files detected in 'polish/cov_filter': {coverage_info_filepaths}.")
 
             # Add the filtered contig information onto a contig info file
-            contig_info = pd.read_csv(input.coverage_info, sep='\t')
+            contig_info = pd.read_csv(input.contig_info, sep='\t')
 
             passed_coverage_filter = []
             for contig_id in contig_info['contig']:
-                if contig_id in contigs:
+                if contig_id in contigs.values:
                     passed_coverage_filter.append('Y')
                 else:
                     passed_coverage_filter.append('N')

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -254,7 +254,8 @@ if (config.get("meandepth_cutoff_long_read") != "None") | (config.get("evenness_
             """
 
 
-if (config.get("meandepth_cutoff_short_read") == "None") & (config.get("evenness_cutoff_short_read") == "None") & \
+if ((POLISH_WITH_SHORT_READS == False) |
+        (config.get("meandepth_cutoff_short_read") == "None") & (config.get("evenness_cutoff_short_read") == "None")) & \
         (config.get("meandepth_cutoff_long_read") == "None") & (config.get("evenness_cutoff_long_read") == "None"):
 
     rule bypass_coverage_filter:

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -266,17 +266,17 @@ if ((POLISH_WITH_SHORT_READS == False) |
             contigs="{sample}/polish/cov_filter/{sample}_filtered_contigs.fasta",
             contig_info="{sample}/polish/cov_filter/{sample}_filtration_summary.tsv"
         run:
+            import shutil
             import pandas as pd
 
-            # Symlink the pre-filtered contig file rather than perform filtration
-            source_relpath = os.path.relpath(str(input.contigs),os.path.dirname(str(output.contigs)))
-            os.symlink(source_relpath,str(output.contigs))
+            # Copy the pre-filtered contig file rather than perform filtration
+            shutil.copyfile(str(input.contigs), str(output.contigs), follow_symlinks=True)
 
             # Write output summary file based on the assembly guide file
             contig_info = pd.read_csv(input.contig_info, sep='\t')
-            contig_info['pass_coverage_filter'] = True
+            contig_info['pass_coverage_filter'] = 'Y'
 
-            contig_info.to_csv(output.contig_info)
+            contig_info.to_csv(output.contig_info, sep='\t', index=False)
 
 
 else:
@@ -359,13 +359,13 @@ else:
             passed_coverage_filter = []
             for contig_id in contig_info['contig']:
                 if contig_id in contigs:
-                    passed_coverage_filter.append(True)
+                    passed_coverage_filter.append('Y')
                 else:
-                    passed_coverage_filter.append(False)
+                    passed_coverage_filter.append('N')
 
             contig_info['pass_coverage_filter'] = passed_coverage_filter
 
-            contig_info.to_csv(output.contig_info_with_coverage, index=False)
+            contig_info.to_csv(output.contig_info_with_coverage, sep='\t', index=False)
             contigs.to_csv(output.filtered_contig_list, header=None, index=False)
 
 


### PR DESCRIPTION
Fixes a couple intertwined issues in rule `summarize_contigs_by_coverage` that caused errors when running rotary in long read only mode, to address one part of #118 

In the previous version of rotary, long-read only mode actually worked with rule `summarize_contigs_by_coverage`, but only when a coverage filter threshold was supplied in the config file. The rule resulted in an error when no long read coverage filter thresholds were supplied (which is the config default) in long-read only mode.

In this update, the following changes were made to address this problem:
- rule `summarize_contigs_by_coverage` was moved inside a conditional block (as it should have always been) so that it only runs when some kind of coverage filtration is requested
- a basic report summarizing the results of coverage filtration was created -- this is symlinked to `{sample}/polish/{sample}_contig_info.tsv`. This report is made whether coverage filtration is performed or not.
- the above report is used to parse out which contigs to run circularization on in checkpoint `split_circular_and_linear_contigs` -- before, no report was made if coverage filtration was not run, causing this checkpoint to fail.

Because of how rule `summarize_contigs_by_coverage` was moved into an existing conditional block in `polish.smk`, the git diff does not show the file changes very cleanly -- my apologies!

In the long term, I think it might make sense to move the code in `summarize_contigs_by_coverage` into a Python utility script -- this would make it easier to write/run tests on some of the logic being performed in this code.

Let me know if you have any thoughts -- thanks!