### PR TITLE
Make compatible with pungi updates

### DIFF
--- a/rotary/config.yaml
+++ b/rotary/config.yaml
@@ -90,7 +90,7 @@ keep_unrepaired_contigs: 'True'
 ## Polishing
 # Model: set this parameter to match the flow cell version / basecalling model you used to generate the long reads.
 #        See details in the Medaka Github repo's "Models" section: https://github.com/nanoporetech/medaka#models
-medaka_model: "r941_min_sup_g507"
+medaka_model: "r1041_e82_400bps_hac_v4.2.0"
 # Batch size: related to memory usage; can reduce if you get OOM (out of memory) errors
 medaka_batch_size: 100
 # Should the pipeline polish with short reads using Polypolish and pypolca?

--- a/rotary/envs/annotation_dfast.yaml
+++ b/rotary/envs/annotation_dfast.yaml
@@ -3,4 +3,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - biopython=1.78
   - dfast=1.2.18 # remember to update VERSION_DFAST at top of snakefile when updating

--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -125,7 +125,7 @@ def init(args):
 
     input_path = get_cli_arg_path(args, 'input_dir')
 
-    dataset = generate_dataset_from_fastq_directory(input_path)
+    dataset = generate_dataset_from_fastq_directory(input_path, expected_files_per_sample=3)
 
     dataset.create_sample_tsv(output_dir_path, header = sample_tsv_header_fields)
 

--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -79,8 +79,14 @@ def run_one(args):
     """
     output_dir_path = get_cli_arg_path(args, 'output_dir')
 
+    config_path = get_cli_arg_path(args, 'config')
+    if not config_path:  # If no config is specified via CLI grab the default config.yaml.
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
+
+    config = load_yaml_config(config_path)
+
     # Checks for existing run files and sets up the run directory.
-    config_path = setup_run_directory(args, output_dir_path, run_files)
+    setup_run_directory(args, output_dir_path, run_files, config)
 
     jobs = get_cli_arg(args, 'jobs')
     snakemake_args = get_snakemake_args(args)
@@ -99,7 +105,6 @@ def run_one(args):
 
     dataset.create_sample_tsv(output_dir_path, header=sample_tsv_header_fields)
 
-    config = load_yaml_config(config_path)
     conda_env_dir = os.path.join(config['db_dir'], 'rotary_conda_envs')
 
     run_snakemake_workflow(config_path=config_path, snake_file_path=snake_file_path, output_dir_path=output_dir_path,

--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -65,12 +65,10 @@ def run(args):
         config_path = os.path.join(output_dir_path, 'config.yaml')
 
     config = load_yaml_config(config_path)
-
-    conda_env_directory = os.path.join(config['db_dir'], 'rotary_conda_env')
-    os.makedirs(conda_env_directory, exist_ok=True)
+    conda_env_dir = os.path.join(config['db_dir'], 'rotary_conda_envs')
 
     run_snakemake_workflow(config_path=config_path, snake_file_path=snake_file_path, output_dir_path=output_dir_path,
-                           jobs=jobs, conda_env_directory=conda_env_directory, snakemake_custom_args=snakemake_args)
+                           jobs=jobs, conda_env_dir_path=conda_env_dir, snakemake_custom_args=snakemake_args)
 
 
 def run_one(args):
@@ -82,7 +80,7 @@ def run_one(args):
     output_dir_path = get_cli_arg_path(args, 'output_dir')
 
     # Checks for existing run files and sets up the run directory.
-    conda_env_directory, config_path = setup_run_directory(args, output_dir_path, run_files)
+    config_path = setup_run_directory(args, output_dir_path, run_files)
 
     jobs = get_cli_arg(args, 'jobs')
     snakemake_args = get_snakemake_args(args)
@@ -101,9 +99,11 @@ def run_one(args):
 
     dataset.create_sample_tsv(output_dir_path, header=sample_tsv_header_fields)
 
+    config = load_yaml_config(config_path)
+    conda_env_dir = os.path.join(config['db_dir'], 'rotary_conda_envs')
+
     run_snakemake_workflow(config_path=config_path, snake_file_path=snake_file_path, output_dir_path=output_dir_path,
-                           jobs=jobs,
-                           conda_env_directory=conda_env_directory, snakemake_custom_args=snakemake_args)
+                           jobs=jobs, conda_env_dir_path=conda_env_dir, snakemake_custom_args=snakemake_args)
 
 
 def init(args):

--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -11,14 +11,15 @@ import os
 from pungi.dataset import generate_dataset_from_fastq_directory, Dataset
 from pungi.run import setup_run_directory, run_snakemake_workflow, load_yaml_config, get_snakemake_args
 from pungi.sample import SequencingFile, LongReadSampleWithPairedPolishingShortReads
-from pungi.utils import get_cli_arg_path, get_cli_arg, check_for_files
+from pungi.utils import get_cli_arg_path, get_cli_arg, check_for_files, get_config_path
 
 rotary_config_name = 'config.yaml'
 run_files = [rotary_config_name, 'samples.tsv']
 
 snake_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'rules', 'rotary.smk')
-
+provided_config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
 sample_tsv_header_fields = ['sample_id', 'long-read', 'short-read_R1', 'short-read_R2']
+
 
 def main():
     """
@@ -60,9 +61,7 @@ def run(args):
     jobs = get_cli_arg(args, 'jobs')
     snakemake_args = get_snakemake_args(args)
 
-    config_path = get_cli_arg_path(args, 'config')
-    if not config_path:
-        config_path = os.path.join(output_dir_path, 'config.yaml')
+    config_path = get_config_path(args, default_config_path=os.path.join(output_dir_path, 'config.yaml'))
 
     config = load_yaml_config(config_path)
     conda_env_dir = os.path.join(config['db_dir'], 'rotary_conda_envs')
@@ -77,13 +76,9 @@ def run_one(args):
 
     :param args: The command-line arguments.
     """
-    output_dir_path = get_cli_arg_path(args, 'output_dir')
-
-    config_path = get_cli_arg_path(args, 'config')
-    if not config_path:  # If no config is specified via CLI grab the default config.yaml.
-        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
-
+    config_path = get_config_path(args, default_config_path=provided_config_path)
     config = load_yaml_config(config_path)
+    output_dir_path = get_cli_arg_path(args, 'output_dir')
 
     # Checks for existing run files and sets up the run directory.
     setup_run_directory(args, output_dir_path, run_files, config)
@@ -98,8 +93,10 @@ def run_one(args):
     sample = LongReadSampleWithPairedPolishingShortReads(long_file=sequencing_files[0],
                                                          short_file_left=sequencing_files[1],
                                                          short_file_right=sequencing_files[2],
-                                                         identifier_check=False, # Don't do integrity check on user-specified files.
-                                                         integrity_check=False)  # Don't do an identifier check on user-specified files.
+                                                         # Don't do an identifier check on user-specified files.
+                                                         identifier_check=False,
+                                                         # Don't do integrity check on user-specified files.
+                                                         integrity_check=False)
 
     dataset = Dataset(sample)
 
@@ -117,13 +114,8 @@ def init(args):
 
     :param args: The command-line arguments.
     """
+    config = load_yaml_config(get_config_path(args, default_config_path=provided_config_path))
     output_dir_path = get_cli_arg_path(args, 'output_dir')
-
-    config_path = get_cli_arg_path(args, 'config')
-    if not config_path:  # If no config is specified via CLI grab the default config.yaml.
-        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
-
-    config = load_yaml_config(config_path)
 
     # Checks for existing run files and sets up the run directory.
     setup_run_directory(args, output_dir_path, run_files, config)
@@ -132,7 +124,7 @@ def init(args):
 
     dataset = generate_dataset_from_fastq_directory(input_path, expected_files_per_sample=3)
 
-    dataset.create_sample_tsv(output_dir_path, header = sample_tsv_header_fields)
+    dataset.create_sample_tsv(output_dir_path, header=sample_tsv_header_fields)
 
 
 def parse_cli():

--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -114,8 +114,14 @@ def init(args):
     """
     output_dir_path = get_cli_arg_path(args, 'output_dir')
 
+    config_path = get_cli_arg_path(args, 'config')
+    if not config_path:  # If no config is specified via CLI grab the default config.yaml.
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
+
+    config = load_yaml_config(config_path)
+
     # Checks for existing run files and sets up the run directory.
-    setup_run_directory(args, output_dir_path, run_files)
+    setup_run_directory(args, output_dir_path, run_files, config)
 
     input_path = get_cli_arg_path(args, 'input_dir')
 


### PR DESCRIPTION
Changes to rotary to make it compatible with the latest pungi updates detailed here: https://github.com/rotary-genomics/pungi/pull/3

- move pathing to the default config back into rotary rather than pungi. Utilizes pungi's `get_config_path` function.
- pass the config object to `setup_run_directory` rather than the pass.
- some minor variable renaming and documentation improvements.