### PR TITLE
Allow for no short read input

### DIFF
--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -123,7 +123,12 @@ def init(args):
 
     input_path = get_cli_arg_path(args, 'input_dir')
 
-    dataset = generate_dataset_from_fastq_directory(input_path, expected_files_per_sample=3)
+    if get_cli_arg(args, 'no_short'):
+        expected_files_per_sample = 1
+    else:
+        expected_files_per_sample = 3
+
+    dataset = generate_dataset_from_fastq_directory(input_path, expected_files_per_sample=expected_files_per_sample)
 
     dataset.create_sample_tsv(output_dir_path, header=sample_tsv_header_fields)
 
@@ -189,6 +194,8 @@ def parse_cli():
                              help='path to a directory containing Oxford Nanopore long-read and Illumina short-read .fastq(.gz) files')
     parser_init.add_argument('-f', '--force', action='store_true',
                              help="override existing run configuration files.")
+    parser_init.add_argument('-ns', '--no_short', action='store_true',
+                             help="do not search for short read files")
     parser_init.set_defaults(init=True)
     return parser
 

--- a/rotary/rotary.py
+++ b/rotary/rotary.py
@@ -90,7 +90,7 @@ def run_one(args):
     sequencing_files = [SequencingFile(path) for path in sequencing_file_cli_paths if path]
 
     if len(sequencing_files) in [1, 3]:
-        sample = auto_create_sample_from_files(sequencing_files,
+        sample = auto_create_sample_from_files(*sequencing_files,
                                                # Don't do an identifier check on user-specified files.
                                                identifier_check=False,
                                                # Don't do integrity check on user-specified files.

--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -9,6 +9,11 @@ from pungi.utils import symlink_or_compress, is_config_parameter_true
 SAMPLE_TSV_PATH = 'samples.tsv'
 SAMPLES = generate_dataset_from_sample_tsv(SAMPLE_TSV_PATH)
 
+if SAMPLES.files_per_sample==3:
+    DATASET_HAS_SHORT_READS=True
+else:
+    DATASET_HAS_SHORT_READS=False
+
 SAMPLE_NAMES = list(SAMPLES.identifiers)
 
 # Specify the minimum snakemake version allowable
@@ -18,6 +23,9 @@ shell.executable("/bin/bash")
 shell.prefix("set -o pipefail; ")
 
 POLISH_WITH_SHORT_READS = is_config_parameter_true(config,'polish_with_short_reads')
+
+if DATASET_HAS_SHORT_READS is False:
+    POLISH_WITH_SHORT_READS=False
 
 rule all:
     input:
@@ -32,14 +40,16 @@ rule set_up_sample_directories:
         SAMPLE_TSV_PATH
     output:
         long_reads = expand("{sample}/raw/{sample}_long.fastq.gz", sample=SAMPLE_NAMES),
-        short_R1_reads = expand("{sample}/raw/{sample}_R1.fastq.gz", sample=SAMPLE_NAMES),
-        short_R2_reads = expand("{sample}/raw/{sample}_R2.fastq.gz", sample=SAMPLE_NAMES)
+        short_R1_reads = expand("{sample}/raw/{sample}_R1.fastq.gz", sample=SAMPLE_NAMES) if DATASET_HAS_SHORT_READS else [],
+        short_R2_reads = expand("{sample}/raw/{sample}_R2.fastq.gz", sample=SAMPLE_NAMES) if DATASET_HAS_SHORT_READS else []
     run:
         for sample in SAMPLES:
             identifier = sample.identifier
             symlink_or_compress(sample.long_read_path,f'{identifier}/raw/{identifier}_long.fastq.gz')
-            symlink_or_compress(sample.short_read_left_path,f'{identifier}/raw/{identifier}_R1.fastq.gz')
-            symlink_or_compress(sample.short_read_right_path,f'{identifier}/raw/{identifier}_R2.fastq.gz')
+
+            if DATASET_HAS_SHORT_READS:
+                symlink_or_compress(sample.short_read_left_path,f'{identifier}/raw/{identifier}_R1.fastq.gz')
+                symlink_or_compress(sample.short_read_right_path,f'{identifier}/raw/{identifier}_R2.fastq.gz')
 
 # Include various modules.
 include: './qc.smk'


### PR DESCRIPTION
### Modify the code so that short reads are no longer required.

Previously, you would have to make mock short read files to get the pipeline to start if you didn't have short reads.

## Changes

- Modify CLI
  - modify `rotary run_one` so the `-r1` and `-r2` flags are optional.
  - modify `rotary init` to add a '--no_short` flag to tell the `rotary` that the input directory contains no short reads.
  - modify `rotary` and `pungi` codes so they can read and write a `samples.tsv` file with only a long sample file column but no short read file columns.
  -  modify `rotary.smk`'s `set_up_sample_directories` rule to take short reads optionally. Also modify it so if there are no short reads that the `POLISH_WITH_SHORT_READS` parameter is set to `False`


## Limitations

Sample directories can either contain only long and short reads or all long reads, but not a mix of both. The  `rotary init` 's `--no_short` cannot be activated while importing a directory containing short reads.