### PR TITLE
Optimize medaka parallelization

### DIFF
--- a/rotary/envs/medaka.yaml
+++ b/rotary/envs/medaka.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - medaka=1.8.0
   - parallel
-  - seqtk=1.3
+  - seqkit=2.8.0

--- a/rotary/envs/medaka.yaml
+++ b/rotary/envs/medaka.yaml
@@ -4,3 +4,5 @@ channels:
   - defaults
 dependencies:
   - medaka=1.8.0
+  - parallel
+  - seqtk=1.3

--- a/rotary/envs/medaka.yaml
+++ b/rotary/envs/medaka.yaml
@@ -4,4 +4,3 @@ channels:
   - defaults
 dependencies:
   - medaka=1.8.0
-  - seqkit=2.8.0

--- a/rotary/envs/medaka.yaml
+++ b/rotary/envs/medaka.yaml
@@ -4,5 +4,4 @@ channels:
   - defaults
 dependencies:
   - medaka=1.8.0
-  - parallel
   - seqkit=2.8.0

--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -272,14 +272,19 @@ rule bypass_circularization:
         os.symlink(source_relpath,str(output))
 
 
-# Gets the names of all lists in circularize/filter/lists (should be either circular.list or linear.list or both)
-# Then outputs the expected paths of the finalized circular and linear FastA files
-# This function allows the DAG to figure out whether to run the circular / linear specific processing steps
-#   based on the split_circular_and_linear_contigs checkpoint made earlier.
+
 def aggregate_contigs(wildcards):
-    # TODO - I do not further use this variable, but checkpoints needs to be called to trigger the checkpoint.
-    # Am I doing something wrong?
-    checkpoint_output = checkpoints.split_circular_and_linear_contigs.get(**wildcards).output[0]
+    """
+    Gets the names of all lists in circularize/filter/lists (should be either circular.list or linear.list or both)
+    Then outputs the expected paths of the finalized circular and linear FastA files
+    This function allows the DAG to figure out whether to run the circular / linear specific processing steps
+    based on the split_circular_and_linear_contigs checkpoint made earlier.
+    """
+    # Force execution of checkpoint split_circular_and_linear_contigs.
+    # Passes wildcards from rule combine_circular_and_linear_contigs to split_circular_and_linear_contigs.
+    # Execution will generate a lists of linear and circular contigs and revaluate the DAG.
+    checkpoints.split_circular_and_linear_contigs.get(**wildcards)
+
     circularize_lists_path = f"{wildcards.sample}/circularize/filter/lists"
 
     return expand("{{sample}}/circularize/combine/{{sample}}_{circular_or_linear}.fasta",

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -47,16 +47,14 @@ checkpoint generate_contig_manifest:
     input:
         "{sample}/{step}/medaka_input/{sample}_input.fasta"
     output:
-        contig_manifest="{sample}/{step}/medaka/{sample}_contigs.txt"
-    conda:
-        "../envs/medaka.yaml"
+        "{sample}/{step}/medaka/{sample}_contigs.txt"
     log:
         "{sample}/logs/{step}/contig_names_medaka.log"
     benchmark:
         "{sample}/benchmarks/{step}/medaka.txt"
     shell:
         """
-        seqkit seq -n {input} > {output.contig_manifest} 2>> {log}
+        grep '^>' {input} | cut -f1 -d' ' | tr -d '>' > {output} 2>> {log}
         """
 
 rule polish_contig_medaka:

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -62,8 +62,7 @@ checkpoint generate_contig_manifest:
 rule polish_contig_medaka:
     input:
         calls_to_draft_bam='{sample}/{step}/medaka/calls_to_draft.bam',
-        calls_to_draft_bam_index='{sample}/{step}/medaka/calls_to_draft.bam.bai',
-        contig_manifest="{sample}/{step}/medaka/{sample}_contigs.txt"
+        calls_to_draft_bam_index='{sample}/{step}/medaka/calls_to_draft.bam.bai'
     output:
         contig_polished=temp('{sample}/{step}/medaka/results/{sample}_{contig}.hd5')
     conda:
@@ -75,13 +74,11 @@ rule polish_contig_medaka:
     params:
         medaka_model=config.get("medaka_model"),
         batch_size=config.get("medaka_batch_size"),
-        medaka_results_dir='{sample}/{step}/medaka/results',
     threads:
         2
     shell:
         """
-        medaka consensus {input.calls_to_draft_bam} \
-          {params.medaka_results_dir}/{wildcards.sample}_{wildcards.contig}.hd5 \
+        medaka consensus {input.calls_to_draft_bam} {output.contig_polished} \
           --model {params.medaka_model} \
           --batch {params.batch_size} \
           --threads {threads} \
@@ -92,7 +89,7 @@ def aggregate_medaka_polished_contigs(wildcards):
     """
     Callback function that generates a list contig HDF5 files that will be needed for rule stitch_medaka.
 
-    :param wildcards: These are the wildcards present in rule stich_medaka.
+    :param wildcards: These are the wildcards present in rule stitch_medaka.
     :return: HDF5 files to be generated for each contig by multiple executions of rule polish_contig_medaka.
     """
     # Force execution of checkpoint generate_contig_files.

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -46,8 +46,7 @@ checkpoint generate_contig_manifest:
     input:
         "{sample}/{step}/medaka_input/{sample}_input.fasta"
     output:
-        contig_manifest="{sample}/{step}/medaka/results/{sample}_contigs.txt",
-        medaka_results_dir=directory('{sample}/{step}/medaka/results')
+        contig_manifest="{sample}/{step}/medaka/results/{sample}_contigs.txt"
     conda:
         "../envs/medaka.yaml"
     log:
@@ -63,10 +62,9 @@ rule polish_contig_medaka:
     input:
         calls_to_draft_bam='{sample}/{step}/medaka/calls_to_draft.bam',
         calls_to_draft_bam_index='{sample}/{step}/medaka/calls_to_draft.bam.bai',
-        medaka_results_dir='{sample}/{step}/medaka/results',
         contig_manifest="{sample}/{step}/medaka/results/{sample}_contigs.txt"
     output:
-        contig_polished='{sample}/{step}/medaka/results/{sample}_{contig}.hd5'
+        contig_polished=temp('{sample}/{step}/medaka/results/{sample}_{contig}.hd5')
     conda:
         "../envs/medaka.yaml"
     log:
@@ -75,13 +73,14 @@ rule polish_contig_medaka:
         "{sample}/benchmarks/{step}/medaka_{sample}_{contig}.txt"
     params:
         medaka_model=config.get("medaka_model"),
-        batch_size=config.get("medaka_batch_size")
+        batch_size=config.get("medaka_batch_size"),
+        medaka_results_dir='{sample}/{step}/medaka/results',
     threads:
         2
     shell:
         """
         medaka consensus {input.calls_to_draft_bam} \
-          {input.medaka_results_dir}/{wildcards.sample}_{wildcards.contig}.hd5 \
+          {params.medaka_results_dir}/{wildcards.sample}_{wildcards.contig}.hd5 \
           --model {params.medaka_model} \
           --batch {params.batch_size} \
           --threads {threads} \

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -42,33 +42,57 @@ rule map_long_reads_for_medaka:
         mini_align -i {input.qc_long_reads} -r {input.contigs} -m -p {params.output_base_name} -t {threads} > {log} 2>&1
         """
 
-rule polish_medaka:
+checkpoint generate_contig_files:
     input:
-        calls_to_draft_bam ='{sample}/{step}/medaka/calls_to_draft.bam',
-        calls_to_draft_bam_index='{sample}/{step}/medaka/calls_to_draft.bam.bai',
-        contigs="{sample}/{step}/medaka_input/{sample}_input.fasta"
+        "{sample}/{step}/medaka_input/{sample}_input.fasta"
     output:
         directory("{sample}/{step}/medaka/results")
     conda:
         "../envs/medaka.yaml"
     log:
-        "{sample}/logs/{step}/medaka.log"
+        "{sample}/logs/{step}/contig_names_medaka.log"
     benchmark:
         "{sample}/benchmarks/{step}/medaka.txt"
+    shell:
+        """
+        mkdir -p {output}
+        seqkit seq -n {input} | parallel 'touch {output}/{wildcards.sample}_{{}}' 2>> {log}
+        """
+
+rule polish_contig_medaka:
+    input:
+        calls_to_draft_bam='{sample}/{step}/medaka/calls_to_draft.bam',
+        calls_to_draft_bam_index='{sample}/{step}/medaka/calls_to_draft.bam.bai',
+        medaka_results_dir='{sample}/{step}/medaka/results',
+        contig_name='{sample}/{step}/medaka/results/{sample}_{contig}'
+    output:
+        contig_polished='{sample}/{step}/medaka/results/{sample}_{contig}.hd5'
+    conda:
+        "../envs/medaka.yaml"
+    log:
+        "{sample}/logs/{step}/medaka_{sample}_{contig}.log"
+    benchmark:
+        "{sample}/benchmarks/{step}/medaka_{sample}_{contig}.txt"
     params:
         medaka_model=config.get("medaka_model"),
         batch_size=config.get("medaka_batch_size")
     threads:
-        round(config.get("threads",1) / 2)
+        2
     shell:
         """
-        mkdir -p {output}
-        seqkit seq -n {input.contigs} | parallel -k -j {threads} 'medaka consensus {input.calls_to_draft_bam} {output}/{{}}.hdf --model {params.medaka_model} --batch {params.batch_size} --threads 2 --region {{}}' > {log} 2>&1
+        medaka consensus {input.calls_to_draft_bam} {input.medaka_results_dir}/{wildcards.sample}_{wildcards.contig}.hd5 \ 
+        --model {params.medaka_model} --batch {params.batch_size} --threads {threads} \
+        --region {wildcards.contig} > {log} 2>&1
         """
+
+def aggregate_medaka_polished_contig_hdf5(wildcards):
+    checkpoints.generate_contig_files.get(sample=wildcards.sample, step=wildcards.step)
+    contigs_names = glob_wildcards(f"{wildcards.sample}/{wildcards.step}/medaka/results/{wildcards.sample}_{{contig}}.hd5").contig
+    return expand(f"{wildcards.sample}/{wildcards.step}/medaka/results/{wildcards.sample}_{{contig}}.hd5", id=contigs_names)
 
 rule stitch_medaka:
     input:
-        hdf5_dir="{sample}/{step}/medaka/results",
+        hdf5s=aggregate_medaka_polished_contig_hdf5,
         draft_fasta="{sample}/polish/medaka_input/{sample}_input.fasta"
     output:
         "{sample}/{step}/medaka/{sample}_consensus.fasta"
@@ -85,7 +109,7 @@ rule stitch_medaka:
         batch_size=config.get("medaka_batch_size")
     shell:
         """
-        medaka stitch --threads {threads} {input.hdf5_dir}/*.hdf {input.draft_fasta} {output} > {log} 2>&1
+        medaka stitch --threads {threads} {input.hdf5s} {input.draft_fasta} {output} > {log} 2>&1
         """
 
 


### PR DESCRIPTION
@jmtsuji This is a bodge that partially addresses https://github.com/rotary-genomics/rotary/issues/131. After some testing it only makes the code 1% faster (code goes to 2 threads for the longest contig in the end). If you had a genome with lots of big contigs (multiple chromosomes) or multiple genomes then there would be greater speed ups.

@jmtsuji This code works. Can you review it to make sure I'm not making any mistakes in the overall logic?

Right now I am work on another branch https://github.com/rotary-genomics/rotary/tree/optimize_medaka_parallelization_by_contig to make it so it polishes each contig in a separate rule instanced spawned by a checkpoint reevaluation of the DAG after it figures out how what contigs were produced by the assembly. This is cleaner and more scalable (the schedular can interweave polishing across contigs and organisms if each polishing rule is set up as taking two threads) but a little harder to right code for.

--------

optimize_medaka_parallelization_by_contig has been merged in.

The code now uses a checkpoint and aggregating function to dynamically run medaka polishing by contig.

This should provide significant speed-ups when running multiple genomes or large chromosomes simultaneously.