### PR TITLE
Change the contig info file added to the stats folder

### DIFF
--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -104,20 +104,9 @@ rule finalize_assembly:
         os.symlink(source_relpath,str(output.info))
 
 
-rule add_circular_info_to_annotation_stats:
-    input:
-        "{sample}/assembly/{sample}_circular_info.tsv"
-    output:
-        "{sample}/stats/{sample}_circular_info.tsv"
-    shell:
-        """
-        cp {input} {output}
-        """
-
 rule assembly:
     input:
         expand("{sample}/assembly/{sample}_assembly.fasta",sample=SAMPLE_NAMES),
-        expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES),
-        expand("{sample}/stats/{sample}_circular_info.tsv", sample=SAMPLE_NAMES)
+        expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES)
     output:
         temp(touch("checkpoints/assembly"))

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -401,9 +401,23 @@ rule symlink_polish:
         os.symlink(source_relpath_contig_info,str(output.contig_info))
 
 
+# TODO - this rule should eventually be moved to the circularization module,
+#  after a stats summary file is created for that module.
+rule add_contig_info_to_annotation_stats:
+    input:
+        "{sample}/polish/{sample}_contig_info.tsv"
+    output:
+        "{sample}/stats/{sample}_contig_info.tsv"
+    shell:
+        """
+        cp {input} {output}
+        """
+
+
 rule polish:
     input:
         expand("{sample}/polish/{sample}_polish.fasta",sample=SAMPLE_NAMES),
-        expand("{sample}/polish/{sample}_contig_info.tsv",sample=SAMPLE_NAMES)
+        expand("{sample}/polish/{sample}_contig_info.tsv",sample=SAMPLE_NAMES),
+        expand("{sample}/stats/{sample}_contig_info.tsv", sample=SAMPLE_NAMES)
     output:
         temp(touch("checkpoints/polish"))


### PR DESCRIPTION
As discussed in [this thread](https://github.com/rotary-genomics/rotary/pull/145#discussion_r1553187763), the `"{sample}/polish/{sample}_contig_info.tsv"` is now copied to the stats folder in place of the `"{sample}/assembly/{sample}_circular_info.tsv"` file. This should provide more detailed contig stats information to the user.

@LeeBergstrand Mind adding your quick review? Thanks!