### PR TITLE
add code to allow medaka to automatically detect base caller model.

### DIFF
--- a/rotary/config.yaml
+++ b/rotary/config.yaml
@@ -90,7 +90,10 @@ keep_unrepaired_contigs: 'True'
 ## Polishing
 # Model: set this parameter to match the flow cell version / basecalling model you used to generate the long reads.
 #        See details in the Medaka Github repo's "Models" section: https://github.com/nanoporetech/medaka#models
-medaka_model: "r1041_e82_400bps_hac_v4.2.0"
+#        One can specify either 'auto' to allow Medaka to pick the model based on input FASTQ file metadata or specify a
+#        specific model (e.g., "r1041_e82_400bps_hac_v4.2.0"). Specifying a specific model is necessary for older input
+#        FASTQ files that do not have base caller metadata.
+medaka_model: "auto"
 # Batch size: related to memory usage; can reduce if you get OOM (out of memory) errors
 medaka_batch_size: 100
 # Should the pipeline polish with short reads using Polypolish and pypolca?

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -59,8 +59,9 @@ checkpoint generate_contig_manifest:
 
 def generate_medaka_model_command(config):
     """
-    Generate the Medaka model command based on the contents of the config file.
-    Allows for 'auto' to be specified in the config to tell Medaka to determine base caller model based on input data.
+    Callback function that generates the Medaka model command based on parameters in the config file.
+    Allows for 'auto' to be specified for the medaka_model in the config.
+    Specifying 'auto' tells Medaka to determine the base caller version based on metadata in the input FASTA/BAM file.
 
     :param config: The configuration dictionary.
     :return: The Medaka model command.

--- a/rotary/rules/polish.smk
+++ b/rotary/rules/polish.smk
@@ -57,6 +57,23 @@ checkpoint generate_contig_manifest:
         (grep '^>' {input} | cut -f1 -d' ' | tr -d '>' > {output}) 2> {log}
         """
 
+def generate_medaka_model_command(config):
+    """
+    Generate the Medaka model command based on the contents of the config file.
+    Allows for 'auto' to be specified in the config to tell Medaka to determine base caller model based on input data.
+
+    :param config: The configuration dictionary.
+    :return: The Medaka model command.
+    """
+    model = config.get("medaka_model")
+
+    if model.lower() == 'auto':
+        model_command=''
+    else:
+        model_command=f"--model {model}"
+
+    return model_command
+
 rule polish_contig_medaka:
     input:
         calls_to_draft_bam='{sample}/{step}/medaka/calls_to_draft.bam',
@@ -70,14 +87,14 @@ rule polish_contig_medaka:
     benchmark:
         "{sample}/benchmarks/{step}/medaka_{sample}_{contig}.txt"
     params:
-        medaka_model=config.get("medaka_model"),
-        batch_size=config.get("medaka_batch_size"),
+        model_command=generate_medaka_model_command(config),
+        batch_size=config.get("medaka_batch_size")
     threads:
         2
     shell:
         """
         medaka consensus {input.calls_to_draft_bam} {output.contig_polished} \
-          --model {params.medaka_model} \
+          {params.model_command} \
           --batch {params.batch_size} \
           --threads {threads} \
           --region {wildcards.contig} > {log} 2>&1


### PR DESCRIPTION
All Medaka model parameter in the config to auto. Medaka will then parse the FASTQ/BAM to get the base caller mode.

Addresses issue https://github.com/rotary-genomics/rotary/issues/97