### PR TITLE
Allow annotation steps to be be turned on and off in config.

### DIFF
--- a/rotary/annotation.py
+++ b/rotary/annotation.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""
+Created by: Lee Bergstrand (2024)
+
+Description: Code for dealing with genome annotations.
+"""
+
+
+class AnnotationMap(object):
+    """
+    A class representing a map of the genome annotation bioinformatics software to be run on the genome.
+    """
+
+    def __init__(self, annotations):
+        """
+        Initialize the object with the provided annotations.
+        Args:
+            annotations (list[str]): A list annotation software to be run.
+        Dynamic Attributes:
+            dfast_func (bool): True if 'dfast_func' annotation should be run, False otherwise.
+            eggnog (bool): True if 'eggnog' annotation should be run, False otherwise.
+            gtdbtk (bool): True if 'gtdbtk' annotation should be run, False otherwise.
+            checkm2 (bool): True if 'checkm2' annotation should be run, False otherwise.
+            coverage (bool): True if 'coverage' annotation should be run, False otherwise.
+        """
+        self.expected_annotations = ['dfast_func', 'eggnog', 'gtdbtk', 'checkm2', 'coverage']
+
+        # Convert the annotations to be lower cases in case the user makes a small typo.
+        annotations_lower = [anno.lower() for anno in annotations]
+
+        for current_annotation in self.expected_annotations:
+            if current_annotation in annotations_lower:
+                setattr(self, current_annotation, True)  # Set the attributes dynamically.
+            else:
+                setattr(self, current_annotation, False)
+
+    def __repr__(self):
+        """
+        Generate a representation of the object state in the form of AnnotationMap(dfast_func=..., eggnog=..., ...).
+        """
+        repr_parts = []
+        for current_annotation in self.expected_annotations:
+            repr_parts.append(f"{current_annotation}={getattr(self, current_annotation)}")
+        return f"AnnotationMap({', '.join(repr_parts)})"
+
+    def __str__(self):
+        return self.__repr__()

--- a/rotary/config.yaml
+++ b/rotary/config.yaml
@@ -119,6 +119,10 @@ hmm_url: "https://ftp.ncbi.nlm.nih.gov/hmm/current/hmm_PGAP.HMM/TIGR02013.1.HMM"
 hmmsearch_evalue: 1e-40
 
 ## Annotation
+# Select Annotations: DFAST_Func (light annotation), EggNOG (heavy annotation including KEGG),
+# GTDBTk (taxonomy), CheckM2 (genome quality), coverage (read coverage statistics)
+annotations: ['DFAST_Func', 'EggNOG', 'GTDBTk', 'CheckM2', 'coverage']
+
 # GTDB-Tk phylogenetic placement mode:
 #    Set to "full_tree" to use the GTDB-Tk v1 method (needs ~320 GB RAM!)
 #    Otherwise, it will use the v2 phylogenetic placement method needing ~55 GB RAM.

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -3,6 +3,7 @@
 
 import os
 from pungi.utils import is_config_parameter_true
+from rotary.annotation import AnnotationMap
 
 VERSION_DFAST="1.2.18"
 VERSION_EGGNOG="5.0.0" # See http://eggnog5.embl.de/#/app/downloads
@@ -15,33 +16,6 @@ DB_DIR_PATH = config.get('db_dir')
 KEEP_BAM_FILES = is_config_parameter_true(config,'keep_final_coverage_bam_files')
 
 # SAMPLE_NAMES, and POLISH_WITH_SHORT_READS are instantiated in rotary.smk
-
-class AnnotationMap(object):
-    """
-    A class representing a map of the annotation software to be ran on the genome.
-    """
-    def __init__(self, annotations):
-        """
-        Initialize the object with the provided annotations.
-
-        Args:
-            annotations (list[str]): A list annotation software to be run.
-
-        Dynamic Attributes:
-            dfast_func (bool): True if 'dfast_func' annotation should be run, False otherwise.
-            eggnog (bool): True if 'eggnog' annotation should be run, False otherwise.
-            gtdbtk (bool): True if 'gtdbtk' annotation should be run, False otherwise.
-            checkm2 (bool): True if 'checkm2' annotation should be run, False otherwise.
-            coverage (bool): True if 'coverage' annotation should be run, False otherwise.
-        """
-        annotations_lower = [anno.lower() for anno in annotations]
-        expected_annotations = ['dfast_func', 'eggnog', 'gtdbtk', 'checkm2', 'coverage']
-
-        for current_annotation in expected_annotations:
-            if current_annotation in annotations_lower:
-                setattr(self, current_annotation, True)
-            else:
-                setattr(self, current_annotation, False)
 
 ANNOTATION_MAP = AnnotationMap(config.get('annotations'))
 

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -410,8 +410,8 @@ rule summarize_annotation:
         "{sample}/annotation/eggnog/{sample}.emapper.annotations" if ANNOTATION_MAP.eggnog else [],
         "{sample}/annotation/gtdbtk/{sample}_gtdbtk.summary.tsv" if ANNOTATION_MAP.gtdbtk else [],
         "{sample}/annotation/checkm/" if ANNOTATION_MAP.checkm2 else [],
-        "{{sample}}/annotation/coverage/{{sample}}_short_read_coverage.tsv" if ANNOTATION_MAP.coverage else [],
-        "{{sample}}/annotation/coverage/{{sample}}_long_read_coverage.tsv" if POLISH_WITH_SHORT_READS and ANNOTATION_MAP.coverage else [],
+        "{sample}/annotation/coverage/{sample}_short_read_coverage.tsv" if ANNOTATION_MAP.coverage else [],
+        "{sample}/annotation/coverage/{sample}_long_read_coverage.tsv" if POLISH_WITH_SHORT_READS and ANNOTATION_MAP.coverage else [],
         "{sample}/annotation/logs",
         "{sample}/annotation/stats"
     output:

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -156,7 +156,7 @@ rule download_checkm_db:
 rule run_dfast:
     input:
         contigs="{sample}/circularize/{sample}_circularize.fasta",
-        install_finished=os.path.join(DB_DIR_PATH,"checkpoints","dfast_" + VERSION_DFAST)
+        install_finished=os.path.join(DB_DIR_PATH,"checkpoints","dfast_" + VERSION_DFAST) if ANNOTATION_MAP.dfast_func else []
     output:
         dfast_genome="{sample}/annotation/dfast/{sample}_genome.fna",
         dfast_cds="{sample}/annotation/dfast/{sample}_cds.fna",
@@ -174,15 +174,15 @@ rule run_dfast:
     benchmark:
         "{sample}/benchmarks/annotation/annotation_dfast.txt"
     params:
-        db=directory(os.path.join(DB_DIR_PATH,"dfast_" + VERSION_DFAST)),
         strain='{sample}',
-        no_functional_annotation="--no_func_anno" if not ANNOTATION_MAP.dfast_func else ''
+        no_functional_annotation="--no_func_anno" if not ANNOTATION_MAP.dfast_func else '',
+        dfast_db_root = f"--dbroot {DFAST_DB_PATH}" if ANNOTATION_MAP.dfast_func else ''
     threads:
         config.get("threads",1)
     shell:
         """
         dfast --force \
-          --dbroot {params.db} \
+          {params.dfast_db_root} \
           -g {input.contigs} \
           -o {output.outdir} \
           --strain {params.strain} \

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -363,7 +363,7 @@ rule calculate_final_long_read_coverage:
 
 rule symlink_logs:
     input:
-        long_read_coverage="{sample}/annotation/coverage/{sample}_long_read_coverage.tsv",
+        dfast_genome="{sample}/annotation/dfast/{sample}_genome.fna"
     output:
         logs=temp(directory("{sample}/annotation/logs")),
         stats=temp(directory("{sample}/annotation/stats"))

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -16,6 +16,35 @@ KEEP_BAM_FILES = is_config_parameter_true(config,'keep_final_coverage_bam_files'
 
 # SAMPLE_NAMES, and POLISH_WITH_SHORT_READS are instantiated in rotary.smk
 
+class AnnotationMap(object):
+    """
+    A class representing a map of the annotation software to be ran on the genome.
+    """
+    def __init__(self, annotations):
+        """
+        Initialize the object with the provided annotations.
+
+        Args:
+            annotations (list[str]): A list annotation software to be run.
+
+        Dynamic Attributes:
+            dfast_func (bool): True if 'dfast_func' annotation should be run, False otherwise.
+            eggnog (bool): True if 'eggnog' annotation should be run, False otherwise.
+            gtdbtk (bool): True if 'gtdbtk' annotation should be run, False otherwise.
+            checkm2 (bool): True if 'checkm2' annotation should be run, False otherwise.
+            coverage (bool): True if 'coverage' annotation should be run, False otherwise.
+        """
+        annotations_lower = [anno.lower() for anno in annotations]
+        expected_annotations = ['dfast_func', 'eggnog', 'gtdbtk', 'checkm2', 'coverage']
+
+        for current_annotation in expected_annotations:
+            if current_annotation in annotations_lower:
+                setattr(self, current_annotation, True)
+            else:
+                setattr(self, current_annotation, False)
+
+ANNOTATION_MAP = AnnotationMap(config.get('annotations'))
+
 rule download_dfast_db:
     output:
         db=directory(os.path.join(DB_DIR_PATH,"dfast_" + VERSION_DFAST)),
@@ -172,7 +201,8 @@ rule run_dfast:
         "{sample}/benchmarks/annotation/annotation_dfast.txt"
     params:
         db=directory(os.path.join(DB_DIR_PATH,"dfast_" + VERSION_DFAST)),
-        strain='{sample}'
+        strain='{sample}',
+        no_functional_annotation="--no_func_anno" if not ANNOTATION_MAP.dfast_func else ''
     threads:
         config.get("threads",1)
     shell:
@@ -183,6 +213,7 @@ rule run_dfast:
           -o {output.outdir} \
           --strain {params.strain} \
           --locus_tag_prefix {params.strain} \
+          {params.no_functional_annotation} \
           --cpu {threads} > {log} 2>&1
          # --complete t \
          # --seq_names "Chromosome,unnamed" \
@@ -376,11 +407,11 @@ rule symlink_logs:
 rule summarize_annotation:
     input:
         "{sample}/annotation/dfast/{sample}_genome.fna",
-        "{sample}/annotation/eggnog/{sample}.emapper.annotations",
-        "{sample}/annotation/gtdbtk/{sample}_gtdbtk.summary.tsv",
-        "{sample}/annotation/checkm/",
-        expand("{{sample}}/annotation/coverage/{{sample}}_{type}_coverage.tsv",
-            type=["short_read", "long_read"] if POLISH_WITH_SHORT_READS == True else ["long_read"]),
+        "{sample}/annotation/eggnog/{sample}.emapper.annotations" if ANNOTATION_MAP.eggnog else [],
+        "{sample}/annotation/gtdbtk/{sample}_gtdbtk.summary.tsv" if ANNOTATION_MAP.gtdbtk else [],
+        "{sample}/annotation/checkm/" if ANNOTATION_MAP.checkm2 else [],
+        "{{sample}}/annotation/coverage/{{sample}}_short_read_coverage.tsv" if ANNOTATION_MAP.coverage else [],
+        "{{sample}}/annotation/coverage/{{sample}}_long_read_coverage.tsv" if POLISH_WITH_SHORT_READS and ANNOTATION_MAP.coverage else [],
         "{sample}/annotation/logs",
         "{sample}/annotation/stats"
     output:

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -19,9 +19,11 @@ KEEP_BAM_FILES = is_config_parameter_true(config,'keep_final_coverage_bam_files'
 
 ANNOTATION_MAP = AnnotationMap(config.get('annotations'))
 
+DFAST_DB_PATH = os.path.join(DB_DIR_PATH,"dfast_" + VERSION_DFAST)
+
 rule download_dfast_db:
     output:
-        db=directory(os.path.join(DB_DIR_PATH,"dfast_" + VERSION_DFAST)),
+        db_dir=directory(DFAST_DB_PATH),
         install_finished=os.path.join(DB_DIR_PATH,"checkpoints","dfast_" + VERSION_DFAST)
     conda:
         "../envs/annotation_dfast.yaml"
@@ -29,13 +31,11 @@ rule download_dfast_db:
         "logs/download/dfast_db_download.log"
     benchmark:
         "benchmarks/download/dfast_db_download.txt"
-    params:
-        db_dir=os.path.join(DB_DIR_PATH,"dfast_" + VERSION_DFAST)
     shell:
         """
-        mkdir -p {params.db_dir}
-        dfast_file_downloader.py --protein dfast --dbroot {params.db_dir} > {log} 2>&1
-        dfast_file_downloader.py --cdd Cog --hmm TIGR --dbroot {params.db_dir} >> {log} 2>&1
+        mkdir -p {output.db_dir}
+        dfast_file_downloader.py --protein dfast --dbroot {output.db_dir} > {log} 2>&1
+        dfast_file_downloader.py --cdd Cog --hmm TIGR --dbroot {output.db_dir} >> {log} 2>&1
         touch {output.install_finished}
         """
 

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -384,8 +384,8 @@ rule summarize_annotation:
         "{sample}/annotation/eggnog/{sample}.emapper.annotations" if ANNOTATION_MAP.eggnog else [],
         "{sample}/annotation/gtdbtk/{sample}_gtdbtk.summary.tsv" if ANNOTATION_MAP.gtdbtk else [],
         "{sample}/annotation/checkm/" if ANNOTATION_MAP.checkm2 else [],
-        "{sample}/annotation/coverage/{sample}_short_read_coverage.tsv" if ANNOTATION_MAP.coverage else [],
-        "{sample}/annotation/coverage/{sample}_long_read_coverage.tsv" if POLISH_WITH_SHORT_READS and ANNOTATION_MAP.coverage else [],
+        "{sample}/annotation/coverage/{sample}_short_read_coverage.tsv" if POLISH_WITH_SHORT_READS and ANNOTATION_MAP.coverage else [],
+        "{sample}/annotation/coverage/{sample}_long_read_coverage.tsv" if ANNOTATION_MAP.coverage else [],
         "{sample}/annotation/logs",
         "{sample}/annotation/stats"
     output:


### PR DESCRIPTION
Addresses issue https://github.com/rotary-genomics/rotary/issues/140

Allows the user to select what annotations to run based on a list of annotation types in the config file.

```yaml
annotations: ['DFAST_Func', 'EggNOG', 'GTDBTk', 'CheckM2', 'coverage']
```

Changes:

1. A Python class for creating objects that can be queried to determine what annotation steps should run.
2. Code that uses this class to determine what annotations to run.
3. Pass the `--no_func_anno` flag to DFAST if you don't want the light annotation to occur.
4. Use `{sample}_genome.fna` from DFAST as an indicator to symlink the log files to go inside `annotation_summary.zip` as, at minimum, DFAST is always run, unlike the other annotation types.


@jmtsuji Thoughts?