### PR TITLE
Upgrade to GTDB r220 and GTDB-Tk v2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ We envision two possible ways that _rotary_ can be used:
       (e.g., the human genome requires 148 GB). The decontaminating with large genomes step can be skipped 
        in most use cases.
     - Flye requires moderate RAM (e.g., < 64 GB for typical bacterial genome runs)
-    - GTDB-Tk v2 (with GTDB r214) needs ~55 GB RAM
+    - GTDB-Tk v2 (with GTDB r220) needs ~90 GB RAM
     - EggNOG-mapper is a bit slow (e.g., ~40 minutes on 40 CPU threads) and uses ~60-80 GB RAM paired in MMSeqs mode
 
 ## Usage

--- a/rotary/config.yaml
+++ b/rotary/config.yaml
@@ -124,8 +124,8 @@ hmmsearch_evalue: 1e-40
 annotations: ['DFAST_Func', 'EggNOG', 'GTDBTk', 'CheckM2', 'coverage']
 
 # GTDB-Tk phylogenetic placement mode:
-#    Set to "full_tree" to use the GTDB-Tk v1 method (needs ~320 GB RAM!)
-#    Otherwise, it will use the v2 phylogenetic placement method needing ~55 GB RAM.
+#    Set to "full_tree" to use the GTDB-Tk v1 method (needs ~545 GB RAM!)
+#    Otherwise, it will use the v2 phylogenetic placement method needing ~90 GB RAM.
 gtdbtk_mode: "default"
 # EggNOG annotation sensitivity mode (using DIAMOND)
 #    Options: fast, mid-sensitive, sensitive, more-sensitive, very-sensitive, ultra-sensitive

--- a/rotary/envs/gtdbtk.yaml
+++ b/rotary/envs/gtdbtk.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - gtdbtk=2.3.2 # Remember to update VERSION_GTDB in the snakefile if the GTDB version updates
+  - gtdbtk=2.4.0 # Remember to update VERSION_GTDB in rotary/rules/annotation.smk if the GTDB version updates

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -8,7 +8,7 @@ from rotary.annotation import AnnotationMap
 VERSION_DFAST="1.2.18"
 VERSION_EGGNOG="5.0.0" # See http://eggnog5.embl.de/#/app/downloads
 
-VERSION_GTDB_COMPLETE= "214.1" # See https://data.gtdb.ecogenomic.org/releases/
+VERSION_GTDB_COMPLETE= "220.0" # See https://data.gtdb.ecogenomic.org/releases/
 VERSION_GTDB_MAIN=VERSION_GTDB_COMPLETE.split('.')[0] # Remove subversion
 
 DB_DIR_PATH = config.get('db_dir')
@@ -73,7 +73,8 @@ rule download_gtdb_db:
         db_dir_root=os.path.join(DB_DIR_PATH),
         initial_download_dir=os.path.join(DB_DIR_PATH,"release" + VERSION_GTDB_MAIN),
         db_dir=os.path.join(DB_DIR_PATH,"GTDB_" + VERSION_GTDB_COMPLETE),
-        url="https://data.gtdb.ecogenomic.org/releases/release" + VERSION_GTDB_MAIN + "/" + VERSION_GTDB_COMPLETE + "/auxillary_files/gtdbtk_r" + VERSION_GTDB_MAIN + "_data.tar.gz"
+        url=f"https://data.gtdb.ecogenomic.org/releases/release{VERSION_GTDB_MAIN}/{VERSION_GTDB_COMPLETE}/"
+            f"auxillary_files/gtdbtk_package/full_package/gtdbtk_r{VERSION_GTDB_MAIN}_data.tar.gz"
     shell:
         """
         mkdir -p {params.db_dir_root}

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -128,7 +128,7 @@ rule build_gtdb_mash_ref_database:
     threads:
         config.get("threads",1)
     params:
-        fast_ani_genomes_dir=os.path.join(DB_DIR_PATH,"GTDB_" + VERSION_GTDB_COMPLETE,'fastani','database')
+        fast_ani_genomes_dir=os.path.join(DB_DIR_PATH,"GTDB_" + VERSION_GTDB_COMPLETE,'skani','database')
     shell:
         """
         find {params.fast_ani_genomes_dir} -name *_genomic.fna.gz -type f > {output.ref_genome_path_list}


### PR DESCRIPTION
[GTDB r220](https://gtdb.ecogenomic.org/stats/r220) was released today, along with an updated version of [GTDB-Tk](https://github.com/Ecogenomics/GTDBTk/releases/tag/2.4.0). This PR adds the updated GTDB and GTDB-Tk to rotary.

@LeeBergstrand Mind giving this a quick review? Note that I already checked the MASH DB build step, and the command within GTDB-Tk to build the MASH DB still seems the same as before.
