### PR TITLE
Install pungi and spokewrench via conda YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,16 @@ Scalable workflow for long-read DNA assemblies including circular elements
 ### Install
 ```bash
 git clone https://github.com/rotary-genomics/rotary.git
-git clone https://github.com/rotary-genomics/pungi.git
 
 conda env create -n rotary --file=rotary/environment.yml
 
 conda activate rotary
 
-cd pungi
-pip install --editable .
-
 cd ../rotary
 pip install --editable .
+
+# See command line options
+rotary -h
 ```
 
 ### Run One Sample
@@ -80,11 +79,31 @@ as a standalone tool.
 ## Usage
 
 ### Install rotary
+Easy way:
+```bash
+git clone https://github.com/rotary-genomics/rotary.git
+
+conda env create -n rotary --file=rotary/environment.yml
+
+conda activate rotary
+
+cd rotary
+pip install --editable .
+```
+This install takes around 1-2 minutes on an 8-thread laptop with a smooth internet connection.
+
+Developer install: it can be helpful for developers to install pungi, the underlying library for working with
+snakefiles, in an editable configuration for coding work. To install pungi in this way, follow the modified install
+instructions below:
 ```bash
 git clone https://github.com/rotary-genomics/rotary.git
 git clone https://github.com/rotary-genomics/pungi.git
 
-conda env create -n rotary --file=rotary/environment.yml
+# Install using a modified conda env file that omits the automated pungi install
+cat rotary/environment.yml | \
+  sed '/- pip/d' | sed '/pungi/d' \
+  > developer_env.yml
+conda env create -n rotary --file=developer_env.yml
 
 conda activate rotary
 
@@ -93,8 +112,9 @@ pip install --editable .
 
 cd ../rotary
 pip install --editable .
+
+rm ../developer_env.yml
 ```
-This install takes around 5 minutes on an 8-thread laptop.
 
 ### Usage method 1: run one sample
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,13 @@ Scalable workflow for long-read DNA assemblies including circular elements
 ### Install
 ```bash
 git clone https://github.com/rotary-genomics/rotary.git
-git clone https://github.com/rotary-genomics/rotary-utils.git
 git clone https://github.com/rotary-genomics/pungi.git
 
 conda env create -n rotary --file=rotary/environment.yml
 
 conda activate rotary
 
-cd rotary-utils
-pip install --editable .
-
-cd ../pungi
+cd pungi
 pip install --editable .
 
 cd ../rotary
@@ -86,17 +82,13 @@ as a standalone tool.
 ### Install rotary
 ```bash
 git clone https://github.com/rotary-genomics/rotary.git
-git clone https://github.com/rotary-genomics/spokewrench.git
 git clone https://github.com/rotary-genomics/pungi.git
 
 conda env create -n rotary --file=rotary/environment.yml
 
 conda activate rotary
 
-cd spokewrench
-pip install --editable .
-
-cd ../pungi
+cd pungi
 pip install --editable .
 
 cd ../rotary

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,3 @@ dependencies:
   - mamba
   - wget
   - psutil=5.9.5
-  - biopython=1.81
-  - circlator=1.5.5
-  - flye=2.9
-  - minimap2=2.23
-  - samtools=1.15

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,6 @@ dependencies:
   - mamba
   - wget
   - psutil=5.9.5
+  - pip
+  - pip:
+      - git+https://github.com/rotary-genomics/pungi@develop

--- a/rotary/envs/spokewrench.yaml
+++ b/rotary/envs/spokewrench.yaml
@@ -1,0 +1,16 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.9.*
+  - pandas=1.4.*
+  - biopython=1.81
+  - circlator=1.5.5
+  - flye=2.9
+  - minimap2=2.23
+  - samtools=1.15
+  - mummer4
+  - pip
+  - pip:
+      - git+https://github.com/rotary-genomics/spokewrench@develop

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -50,6 +50,8 @@ rule assembly_end_repair:
         assembly="{sample}/assembly/end_repair/{sample}_repaired.fasta",
         info="{sample}/assembly/end_repair/{sample}_repaired_info.tsv",
         output_dir=directory("{sample}/assembly/end_repair")
+    conda:
+        "../envs/spokewrench.yaml"
     log:
         "{sample}/logs/assembly/end_repair.log"
     benchmark:


### PR DESCRIPTION
Moves pungi and spokewrench installs into conda environment configuration (YAML) files. Now, these tools can be installed automatically rather than needing to be installed manually (following conda commands).