### PR TITLE
Snakemake 8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,11 @@ channels:
 dependencies:
   - python=3.9.*
   - pandas=1.4.*
-  - snakemake=7.*
-  - mamba
-  - wget
-  - psutil=5.9.5
-  - pulp=2.7.0 # temporary workaround for installation of snakemake 7 (force downgrade of pulp)
+  - snakemake=8.*
+  - biopython=1.81
+  - mamba=1.5.*
+  - wget=1.21.*
+  - psutil=5.9.*
   - zip=3.*
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python=3.9.*
+  - python=3.11.*
   - pandas=1.4.*
   - snakemake=8.*
   - mamba=1.5.*

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.9.*
   - pandas=1.4.*
   - snakemake=8.*
-  - biopython=1.81
   - mamba=1.5.*
   - wget=1.21.*
   - psutil=5.9.*

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.11.*
-  - pandas=1.4.*
+  - pandas=1.5.*
   - snakemake=8.*
   - mamba=1.5.*
   - wget=1.21.*

--- a/meta.yml
+++ b/meta.yml
@@ -19,7 +19,7 @@ requirements:
     - zip=3.*
 
 build:
-  script: poetry install
+  script: pip install .
 
 test:
   commands:

--- a/meta.yml
+++ b/meta.yml
@@ -13,7 +13,6 @@ requirements:
     - python=3.9.*
     - pandas=1.4.*
     - snakemake=8.*
-    - biopython=1.81
     - mamba=1.5.*
     - wget=1.21.*
     - psutil=5.9.*

--- a/meta.yml
+++ b/meta.yml
@@ -11,7 +11,7 @@ requirements:
     - poetry
   run:
     - python=3.11.*
-    - pandas=1.4.*
+    - pandas=1.5.*
     - snakemake=8.*
     - mamba=1.5.*
     - wget=1.21.*

--- a/meta.yml
+++ b/meta.yml
@@ -12,15 +12,11 @@ requirements:
   run:
     - python=3.9.*
     - pandas=1.4.*
-    - snakemake=7.*
-    - mamba
-    - wget
-    - psutil=5.9.5
+    - snakemake=8.*
     - biopython=1.81
-    - circlator=1.5.5
-    - flye=2.9
-    - minimap2=2.23
-    - samtools=1.15
+    - mamba=1.5.*
+    - wget=1.21.*
+    - psutil=5.9.*
     - zip=3.*
 
 build:

--- a/meta.yml
+++ b/meta.yml
@@ -10,7 +10,7 @@ requirements:
     - python
     - poetry
   run:
-    - python=3.9.*
+    - python=3.11.*
     - pandas=1.4.*
     - snakemake=8.*
     - mamba=1.5.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,10 @@ readme = "README.md"
 
 dependencies = [
     "pandas ~=1.4",
-    "snakemake ~=7.32",
+    "snakemake ~=8",
+    "biopython ~=1.81",
     "psutil ~=5.9",
-    "biopython ~=1.81"
+
 ]
 
 [tool.setuptools.packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "pandas ~=1.4",
     "snakemake ~=8",
     "psutil ~=5.9",
-
 ]
 
 [tool.setuptools.packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ readme = "README.md"
 dependencies = [
     "pandas ~=1.4",
     "snakemake ~=8",
-    "biopython ~=1.81",
     "psutil ~=5.9",
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 
 dependencies = [
-    "pandas ~=1.4",
+    "pandas ~=1.5",
     "snakemake ~=8",
     "psutil ~=5.9",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 dependencies = [
     "pandas ~=1.5",
-    "snakemake ~=8",
+    "snakemake ~=8.0",
     "psutil ~=5.9",
 ]
 


### PR DESCRIPTION
Modify the code to work with snakemake version 8, a significant non-backwards compatible version update.

Addresses issue: https://github.com/rotary-genomics/rotary/issues/111

Being done in coordination with https://github.com/rotary-genomics/pungi/pull/4