### PR TITLE
Aggregate Assembly Stats Across Samples

### DIFF
--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -130,9 +130,34 @@ rule finalize_assembly:
         os.symlink(source_relpath,str(output.info))
 
 
+rule aggregate_assembly_stats_multiqc:
+    input:
+        expand("{sample}/assembly/stats/",sample=SAMPLE_NAMES)
+    output:
+        multqc_report="stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        multqc_report_data="stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+    conda:
+        "../envs/qc.yaml"
+    log:
+        "logs/assembly/assembly_stats_multiqc.log"
+    benchmark:
+        "benchmarks/assembly/assembly_stats_multiqc.txt"
+    params:
+        qc_stats_dir="stats/assembly/"
+    shell:
+        """
+        multiqc --outdir {params.qc_stats_dir} \
+        --title 'all_samples_assembly_stats' \
+        --data-format tsv \
+        --zip-data-dir {input} > {log} 2>&1
+        """
+
+
 rule assembly:
     input:
-        expand("{sample}/assembly/{sample}_assembly.fasta",sample=SAMPLE_NAMES),
-        expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES)
+        assembly_fasta = expand("{sample}/assembly/{sample}_assembly.fasta",sample=SAMPLE_NAMES),
+        assembly_circular_info = expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES),
+        assembly_multqc_report="stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        assembly_multqc_report_data="stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     output:
         temp(touch("checkpoints/assembly"))

--- a/rotary/rules/qc.smk
+++ b/rotary/rules/qc.smk
@@ -424,7 +424,7 @@ rule run_fastq_short:
         fastqc -o {params.outdir} -t {threads} {input} >{log} 2>&1
         """
 
-rule run_multiqc:
+rule run_sample_qc_multiqc:
     input:
         "checkpoints/qc_stats_{type}_{sample}"
     output:


### PR DESCRIPTION
Use MultiQC to aggregate assembly stats generated by QUAST across multiple datasets into a single report.