### PR TITLE
raise value error if no contigs pass coverage filter.

### DIFF
--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -47,6 +47,9 @@ checkpoint split_circular_and_linear_contigs:
         contig_info = pd.read_csv(input[0], sep='\t')
         contig_info_filtered = contig_info[contig_info['pass_coverage_filter'] == 'Y']
 
+        if len(contig_info_filtered) == 0:
+            raise ValueError(f'No contigs pass coverage filter for sample {wildcards.sample}.')
+
         circular_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'Y']
         linear_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'N']
 


### PR DESCRIPTION
Resolves issue https://github.com/rotary-genomics/rotary/issues/199 -- An error occurs when no contigs pass the coverage filter.