### PR TITLE
Qc before after comparison allow kbp gbp values in Total Bases Column

### DIFF
--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -41,7 +41,8 @@ checkpoint split_circular_and_linear_contigs:
     input:
         "{sample}/polish/{sample}_contig_info.tsv"
     output:
-        directory("{sample}/circularize/filter/lists")
+        directory("{sample}/circularize/filter/lists"),
+        directory("{sample}/circularize/medaka")
     run:
         contig_info = pd.read_csv(input[0], sep='\t')
         contig_info_filtered = contig_info[contig_info['pass_coverage_filter'] == 'Y']
@@ -50,10 +51,13 @@ checkpoint split_circular_and_linear_contigs:
         linear_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'N']
 
         os.makedirs(output[0],exist_ok=True)
+        os.makedirs(output[1],exist_ok=True)
 
         # Only output files if there is >=1 entry
         if circular_contigs.shape[0] >= 1:
             circular_contigs['contig'].to_csv(os.path.join(output[0],'circular.list'),header=None,index=False)
+            circular_contigs['contig'].to_csv(os.path.join(output[1],f'{wildcards.sample}_contigs.txt'),
+                header=None,index=False)
 
         if linear_contigs.shape[0] >= 1:
             linear_contigs['contig'].to_csv(os.path.join(output[0],'linear.list'),header=None,index=False)


### PR DESCRIPTION
Refactor functions within `qc.py` for improved readability. The larger datasets showed that the readability column contained kbp, gbp, and mbp strings, not just mbp. Improve the functions within `qc.py` to remove all these strings within the Total Bases column and convert all values to a numeric mbp column. 

| Total Bases | Total Bases (Mbp) |
|------------:|------------------:|
|     125 Kbp |          0.125000 |
|     1.2 Gbp |       1200.000000 |
|      20 mbp |         20.000000 |
|        5 bp |          0.000005 |
|       6 Mbp |          6.000000 |
|      100 BP |          0.000100 |
|       2 GBp |       2000.000000 |

Total Bases = Before Conversion
Total Bases (Mbp) = After Conversion