### PR TITLE
simplify assembly QUAST outputs.

### DIFF
--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -92,8 +92,7 @@ rule assembly_end_repair:
 
 rule run_quast:
     input:
-        flye_assembly = "{sample}/assembly/flye/{sample}_flye_assembly.fasta",
-        end_repair_assembly= "{sample}/assembly/end_repair/{sample}_end_repair_assembly.fasta",
+        flye_assembly = "{sample}/assembly/flye/{sample}_flye_assembly.fasta"
     output:
         stats_dir=directory("{sample}/assembly/stats/"),
         report=multiext("{sample}/assembly/stats/report", '.html', '.tex', '.tsv', '.txt', '.pdf'),

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -108,7 +108,7 @@ rule run_quast:
     shell:
         """
         quast -t {threads} --space-efficient \
-        --labels "{wildcards.sample}_flye, {wildcards.sample}_end_repair" \
+        --labels "{wildcards.sample}_flye" \
         -o {output.stats_dir} {input} > {log} 2>&1
         """
 

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -108,7 +108,7 @@ rule run_quast:
     shell:
         """
         quast -t {threads} --space-efficient \
-        --labels "{wildcards.sample}_flye" \
+        --labels "{wildcards.sample}" \
         -o {output.stats_dir} {input} > {log} 2>&1
         """
 


### PR DESCRIPTION
Remove post-end-repair assemblies from QUAST output, as they are almost always identical to the original assembly and lead to cluttered QUAST graphs.