### PR TITLE
Merge develop_lee into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ conda env create -n rotary --file=rotary/environment.yml
 
 conda activate rotary
 
-cd ../rotary
+cd rotary
 pip install --editable .
 
 # See command line options

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.11.*
   - pandas=1.5.*
-  - snakemake>=8,<8.6.0
+  - snakemake=7.*
   - mamba=1.5.*
   - wget=1.21.*
   - psutil=5.9.*

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.11.*
   - pandas=1.5.*
-  - snakemake=8.*
+  - snakemake>=8,<8.6.0
   - mamba=1.5.*
   - wget=1.21.*
   - psutil=5.9.*

--- a/meta.yml
+++ b/meta.yml
@@ -12,7 +12,7 @@ requirements:
   run:
     - python=3.11.*
     - pandas=1.5.*
-    - snakemake=8.*
+    - snakemake>=8,<8.6.0
     - mamba=1.5.*
     - wget=1.21.*
     - psutil=5.9.*

--- a/meta.yml
+++ b/meta.yml
@@ -12,7 +12,7 @@ requirements:
   run:
     - python=3.11.*
     - pandas=1.5.*
-    - snakemake>=8,<8.6.0
+    - snakemake=7.*
     - mamba=1.5.*
     - wget=1.21.*
     - psutil=5.9.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 dependencies = [
     "pandas ~=1.5",
-    "snakemake >=8.0.0, <8.6.0",
+    "snakemake >=7.0.0, <8.0.0",
     "psutil ~=5.9",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 dependencies = [
     "pandas ~=1.5",
-    "snakemake ~=8.0",
+    "snakemake >=8.0.0, <8.6.0",
     "psutil ~=5.9",
 ]
 

--- a/rotary/annotation.py
+++ b/rotary/annotation.py
@@ -49,16 +49,15 @@ class AnnotationMap(object):
         return self.__repr__()
 
 
-def combine_checkm_reports(report_paths, combined_report_path):
+def combine_tabular_reports(report_paths, combined_report_path, delimiter='\t'):
     """
     This function takes a list of paths to individual checkm TSV reports, combines them into a single dataframe
     and saves the combined dataframe into TSV a specified path.
 
     :param report_paths: List of paths to individual report TSVs
     :param combined_report_path: Path to save the combined TSV report
+    :param delimiter: The column delimiter character for the tabular text report
     """
-    delimiter = '\t'
-
     checkm_dataframes = [pd.read_csv(path, delimiter=delimiter) for path in report_paths]
     combined_dataframe = pd.concat(checkm_dataframes)
     combined_dataframe.to_csv(combined_report_path, sep=delimiter, index=False)

--- a/rotary/annotation.py
+++ b/rotary/annotation.py
@@ -5,6 +5,7 @@ Created by: Lee Bergstrand (2024)
 
 Description: Code for dealing with genome annotations.
 """
+import pandas as pd
 
 
 class AnnotationMap(object):
@@ -46,3 +47,18 @@ class AnnotationMap(object):
 
     def __str__(self):
         return self.__repr__()
+
+
+def combine_checkm_reports(report_paths, combined_report_path):
+    """
+    This function takes a list of paths to individual checkm TSV reports, combines them into a single dataframe
+    and saves the combined dataframe into TSV a specified path.
+
+    :param report_paths: List of paths to individual report TSVs
+    :param combined_report_path: Path to save the combined TSV report
+    """
+    delimiter = '\t'
+
+    checkm_dataframes = [pd.read_csv(path, delimiter=delimiter) for path in report_paths]
+    combined_dataframe = pd.concat(checkm_dataframes)
+    combined_dataframe.to_csv(combined_report_path, sep=delimiter, index=False)

--- a/rotary/envs/pypolca.yaml
+++ b/rotary/envs/pypolca.yaml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - pypolca=0.3.1
+  - freebayes=1.3.7

--- a/rotary/envs/pypolca.yaml
+++ b/rotary/envs/pypolca.yaml
@@ -4,4 +4,4 @@ channels:
   - defaults
 dependencies:
   - pypolca=0.3.1
-  - freebayes=1.3.7
+  - freebayes=1.3.6

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -335,7 +335,7 @@ if POLISH_WITH_SHORT_READS == True:
         output:
             mapping="{sample}/annotation/coverage/{sample}_short_read.bam" if KEEP_BAM_FILES else temp("{sample}/annotation/coverage/{sample}_short_read.bam"),
             index=temp("{sample}/annotation/coverage/{sample}_short_read.bam.bai"),
-            coverage="{sample}/annotation/coverage/{sample}_short_read_coverage.tsv",
+            coverage=temp("{sample}/annotation/coverage/{sample}_short_read_coverage_raw.tsv"),
             read_mapping_files= temp(multiext("{sample}/annotation/dfast/{sample}_genome.fna",
                 *READ_MAPPING_FILE_EXTENSIONS)) # Variable declared in polish.smk
         conda:
@@ -369,7 +369,7 @@ rule calculate_final_long_read_coverage:
     output:
         mapping="{sample}/annotation/coverage/{sample}_long_read.bam" if KEEP_BAM_FILES else temp("{sample}/annotation/coverage/{sample}_long_read.bam"),
         index=temp("{sample}/annotation/coverage/{sample}_long_read.bam.bai"),
-        coverage="{sample}/annotation/coverage/{sample}_long_read_coverage.tsv"
+        coverage=temp("{sample}/annotation/coverage/{sample}_long_read_coverage_raw.tsv")
     conda:
         "../envs/mapping.yaml"
     log:
@@ -391,6 +391,36 @@ rule calculate_final_long_read_coverage:
         samtools index -@ {threads} {output.mapping}
         samtools coverage {output.mapping} > {output.coverage}
         """
+
+
+rule reformat_final_read_coverage:
+    input:
+        "{sample}/annotation/coverage/{sample}_{long_or_short}_read_coverage_raw.tsv"
+    output:
+        "{sample}/annotation/coverage/{sample}_{long_or_short}_read_coverage.tsv"
+    params:
+        sample_id="{sample}",
+        read_type="{long_or_short}"
+    run:
+        read_coverage = pd.read_csv(input[0], sep='\t')\
+            .rename(columns={'#rname':'contig'})
+
+        read_coverage.insert(0, column='sample', value=params.sample_id)
+        read_coverage.insert(1, column='read_type', value=params.read_type)
+
+        read_coverage.to_csv(output[0], sep='\t', index=False)
+
+
+rule aggregate_final_read_coverage:
+    input:
+        expand("{sample}/annotation/coverage/{sample}_{long_or_short}_read_coverage.tsv", sample=SAMPLE_NAMES, long_or_short=['long','short']) \
+            if POLISH_WITH_SHORT_READS == True else expand("{sample}/annotation/coverage/{sample}_long_read_coverage.tsv", sample=SAMPLE_NAMES)
+    output:
+        'aggregate_stats/annotation/aggregate_read_coverage.tsv'
+    benchmark:
+        "benchmarks/annotation/aggregate_read_coverage.txt"
+    run:
+        combine_tabular_reports(input,output[0])
 
 
 rule symlink_logs:
@@ -436,6 +466,7 @@ rule annotation:
     input:
         summeries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
         aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv',
-        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv'
+        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv',
+        aggregate_final_read_coverage='aggregate_stats/annotation/aggregate_read_coverage.tsv'
     output:
         temp(touch("checkpoints/annotation"))

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -3,7 +3,7 @@
 
 import os
 from pungi.utils import is_config_parameter_true
-from rotary.annotation import AnnotationMap, combine_checkm_reports
+from rotary.annotation import AnnotationMap, combine_tabular_reports
 
 VERSION_DFAST="1.2.18"
 VERSION_EGGNOG="5.0.0" # See http://eggnog5.embl.de/#/app/downloads

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -464,9 +464,9 @@ rule summarize_annotation:
 
 rule annotation:
     input:
-        summeries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
-        aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv',
-        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv',
-        aggregate_final_read_coverage='aggregate_stats/annotation/aggregate_read_coverage.tsv'
+        summaries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
+        aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv' if ANNOTATION_MAP.checkm2 else [],
+        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv' if ANNOTATION_MAP.gtdbtk else [],
+        aggregate_final_read_coverage='aggregate_stats/annotation/aggregate_read_coverage.tsv' if ANNOTATION_MAP.coverage else []
     output:
         temp(touch("checkpoints/annotation"))

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -278,6 +278,17 @@ rule run_gtdbtk:
         tail -n +2 {output.outdir}/gtdbtk.*.summary.tsv >> {output.annotation}
         """
 
+rule aggregate_gtdbtk_reports:
+    input:
+        expand("{sample}/annotation/gtdbtk/{sample}_gtdbtk.summary.tsv", sample=SAMPLE_NAMES)
+    output:
+        'stats/annotation/aggregate_gtdbtk_summary_report.tsv'
+    benchmark:
+        "benchmarks/annotation/aggregate_gtdbtk.benchmark.txt"
+    run:
+        combine_tabular_reports(input,output[0])
+
+
 rule run_checkm2:
     input:
         genome="{sample}/annotation/dfast/{sample}_genome.fna",
@@ -311,7 +322,7 @@ rule aggregate_checkm2_reports:
     benchmark:
         "benchmarks/annotation/aggregate_checkm.benchmark.txt"
     run:
-        combine_checkm_reports(input,output[0])
+        combine_tabular_reports(input,output[0])
 
 
 if POLISH_WITH_SHORT_READS == True:
@@ -424,6 +435,7 @@ rule summarize_annotation:
 rule annotation:
     input:
         summeries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
-        aggregate_checkm_report='stats/annotation/aggregate_checkm_quality_report.tsv'
+        aggregate_checkm_report='stats/annotation/aggregate_checkm_quality_report.tsv',
+        aggregate_gtdbtk_report='stats/annotation/aggregate_gtdbtk_summary_report.tsv'
     output:
         temp(touch("checkpoints/annotation"))

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -240,8 +240,8 @@ rule run_eggnog:
         """
         mkdir -p {output.outdir}/tmp
         emapper.py --cpu {threads} -i {input.protein} --itype proteins -m {params.search_tool} \
-          --sensmode {params.sensmode} --dbmem --output eggnog --output_dir {output.outdir} \
-          --temp_dir {output.outdir}/tmp --output {params.prefix} \
+          --sensmode {params.sensmode} --dbmem --output {params.prefix} --output_dir {output.outdir} \
+          --temp_dir {output.outdir}/tmp \
           --data_dir {params.db} --override > {log} 2>&1
         rm -r {output.outdir}/tmp
         """

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -282,7 +282,7 @@ rule aggregate_gtdbtk_reports:
     input:
         expand("{sample}/annotation/gtdbtk/{sample}_gtdbtk.summary.tsv", sample=SAMPLE_NAMES)
     output:
-        'stats/annotation/aggregate_gtdbtk_summary_report.tsv'
+        'aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv'
     benchmark:
         "benchmarks/annotation/aggregate_gtdbtk.benchmark.txt"
     run:
@@ -318,7 +318,7 @@ rule aggregate_checkm2_reports:
     input:
         expand("{sample}/annotation/checkm/{sample}_checkm_quality_report.tsv", sample=SAMPLE_NAMES)
     output:
-        'stats/annotation/aggregate_checkm_quality_report.tsv'
+        'aggregate_stats/annotation/aggregate_checkm_quality_report.tsv'
     benchmark:
         "benchmarks/annotation/aggregate_checkm.benchmark.txt"
     run:
@@ -435,7 +435,7 @@ rule summarize_annotation:
 rule annotation:
     input:
         summeries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
-        aggregate_checkm_report='stats/annotation/aggregate_checkm_quality_report.tsv',
-        aggregate_gtdbtk_report='stats/annotation/aggregate_gtdbtk_summary_report.tsv'
+        aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv',
+        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv'
     output:
         temp(touch("checkpoints/annotation"))

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -92,8 +92,7 @@ rule assembly_end_repair:
 
 rule run_quast:
     input:
-        flye_assembly = "{sample}/assembly/flye/{sample}_flye_assembly.fasta",
-        end_repair_assembly= "{sample}/assembly/end_repair/{sample}_end_repair_assembly.fasta",
+        flye_assembly = "{sample}/assembly/flye/{sample}_flye_assembly.fasta"
     output:
         stats_dir=directory("{sample}/assembly/stats/"),
         report=multiext("{sample}/assembly/stats/report", '.html', '.tex', '.tsv', '.txt', '.pdf'),

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -108,7 +108,7 @@ rule run_quast:
     shell:
         """
         quast -t {threads} --space-efficient \
-        --labels "{wildcards.sample}_flye, {wildcards.sample}_end_repair" \
+        --labels "{wildcards.sample}_flye" \
         -o {output.stats_dir} {input} > {log} 2>&1
         """
 

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -133,8 +133,8 @@ rule aggregate_assembly_stats_multiqc:
     input:
         expand("{sample}/assembly/stats/",sample=SAMPLE_NAMES)
     output:
-        multqc_report="stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        multqc_report_data="stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     conda:
         "../envs/qc.yaml"
     log:
@@ -142,7 +142,7 @@ rule aggregate_assembly_stats_multiqc:
     benchmark:
         "benchmarks/assembly/assembly_stats_multiqc.txt"
     params:
-        qc_stats_dir="stats/assembly/"
+        qc_stats_dir='aggregate_stats/assembly/"
     shell:
         """
         multiqc --outdir {params.qc_stats_dir} \
@@ -156,7 +156,7 @@ rule assembly:
     input:
         assembly_fasta = expand("{sample}/assembly/{sample}_assembly.fasta",sample=SAMPLE_NAMES),
         assembly_circular_info = expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES),
-        assembly_multqc_report="stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        assembly_multqc_report_data="stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        assembly_multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        assembly_multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     output:
         temp(touch("checkpoints/assembly"))

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -108,7 +108,7 @@ rule run_quast:
     shell:
         """
         quast -t {threads} --space-efficient \
-        --labels "{wildcards.sample}_flye" \
+        --labels "{wildcards.sample}" \
         -o {output.stats_dir} {input} > {log} 2>&1
         """
 

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -133,8 +133,8 @@ rule aggregate_assembly_stats_multiqc:
     input:
         expand("{sample}/assembly/stats/",sample=SAMPLE_NAMES)
     output:
-        multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        multqc_report="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        multqc_report_data="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     conda:
         "../envs/qc.yaml"
     log:
@@ -142,7 +142,7 @@ rule aggregate_assembly_stats_multiqc:
     benchmark:
         "benchmarks/assembly/assembly_stats_multiqc.txt"
     params:
-        qc_stats_dir='aggregate_stats/assembly/"
+        qc_stats_dir="aggregate_stats/assembly/"
     shell:
         """
         multiqc --outdir {params.qc_stats_dir} \
@@ -156,7 +156,7 @@ rule assembly:
     input:
         assembly_fasta = expand("{sample}/assembly/{sample}_assembly.fasta",sample=SAMPLE_NAMES),
         assembly_circular_info = expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES),
-        assembly_multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        assembly_multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        assembly_multqc_report="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        assembly_multqc_report_data="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     output:
         temp(touch("checkpoints/assembly"))

--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -47,6 +47,9 @@ checkpoint split_circular_and_linear_contigs:
         contig_info = pd.read_csv(input[0], sep='\t')
         contig_info_filtered = contig_info[contig_info['pass_coverage_filter'] == 'Y']
 
+        if len(contig_info_filtered) == 0:
+            raise ValueError(f'No contigs pass coverage filter for sample {wildcards.sample}.')
+
         circular_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'Y']
         linear_contigs = contig_info_filtered[contig_info_filtered['circular'] == 'N']
 

--- a/rotary/rules/circularize.smk
+++ b/rotary/rules/circularize.smk
@@ -101,7 +101,7 @@ rule search_contig_start:
     shell:
         """
         printf "### Predict genes ###\n" > {log}
-        prodigal -i {input.contigs} -a {output.orf_predictions} -d {output.gene_predictions} \
+        prodigal -i {input.contigs} -a {output.orf_predictions} -d {output.gene_predictions} -p meta \
           -f gff -o {output.annotation_gff} 2>> {log}
 
         printf "\n\n### Find HMM hits ###\n\n" >> {log}

--- a/rotary/rules/qc.smk
+++ b/rotary/rules/qc.smk
@@ -482,7 +482,7 @@ rule generate_long_aggregate_qc_stats:
     input:
         expand("{sample}/qc/qc_stats/long/{sample}_long_multiqc_report_data.zip", sample=SAMPLE_NAMES)
     output:
-        'stats/qc/before_and_after_qc_sequence_stats_long.tsv'
+        'aggregate_stats/qc/before_and_after_qc_sequence_stats_long.tsv'
     benchmark:
         "benchmarks/qc/qc_long_aggregate_stats.benchmark.txt"
     run:
@@ -495,8 +495,8 @@ rule generate_short_aggregate_qc_stats:
     input:
         expand("{sample}/qc/qc_stats/short/{sample}_short_multiqc_report_data.zip", sample=SAMPLE_NAMES)
     output:
-        left_qc_stats='stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv',
-        right_qc_stats='stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv'
+        left_qc_stats='aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv',
+        right_qc_stats='aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv'
     benchmark:
         "benchmarks/qc/qc_short_aggregate_stats.benchmark.txt"
     run:
@@ -515,9 +515,9 @@ rule qc_stats:
 
 rule aggregate_qc_stats:
     input:
-        left_short_qc_stats = 'stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv' if POLISH_WITH_SHORT_READS else [],
-        right_short_qc_stats = 'stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv' if POLISH_WITH_SHORT_READS else [],
-        long_qc_stats = 'stats/qc/before_and_after_qc_sequence_stats_long.tsv'
+        left_short_qc_stats = 'aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv' if POLISH_WITH_SHORT_READS else [],
+        right_short_qc_stats = 'aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv' if POLISH_WITH_SHORT_READS else [],
+        long_qc_stats = 'aggregate_stats/qc/before_and_after_qc_sequence_stats_long.tsv'
     output:
         temp(touch("checkpoints/aggregate_qc_stats"))
 

--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -46,8 +46,6 @@ rule all:
         "checkpoints/annotation"
 
 rule set_up_sample_directory:
-    input:
-        SAMPLE_TSV_PATH
     output:
         long_reads = "{sample}/raw/long/{sample}_long.fastq.gz",
         short_R1_reads = "{sample}/raw/short/{sample}_R1.fastq.gz" if DATASET_HAS_SHORT_READS else [],

--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -45,21 +45,21 @@ rule all:
         "checkpoints/circularize",
         "checkpoints/annotation"
 
-rule set_up_sample_directories:
+rule set_up_sample_directory:
     input:
         SAMPLE_TSV_PATH
     output:
-        long_reads = expand("{sample}/raw/long/{sample}_long.fastq.gz", sample=SAMPLE_NAMES),
-        short_R1_reads = expand("{sample}/raw/short/{sample}_R1.fastq.gz", sample=SAMPLE_NAMES) if DATASET_HAS_SHORT_READS else [],
-        short_R2_reads = expand("{sample}/raw/short/{sample}_R2.fastq.gz", sample=SAMPLE_NAMES) if DATASET_HAS_SHORT_READS else []
+        long_reads = "{sample}/raw/long/{sample}_long.fastq.gz",
+        short_R1_reads = "{sample}/raw/short/{sample}_R1.fastq.gz" if DATASET_HAS_SHORT_READS else [],
+        short_R2_reads = "{sample}/raw/short/{sample}_R2.fastq.gz" if DATASET_HAS_SHORT_READS else []
     run:
-        for sample in SAMPLES:
-            identifier = sample.identifier
-            symlink_or_compress(sample.long_read_path,f'{identifier}/raw/long/{identifier}_long.fastq.gz')
+        sample = SAMPLES[wildcards.sample]
+        identifier = sample.identifier
+        symlink_or_compress(sample.long_read_path,f'{identifier}/raw/long/{identifier}_long.fastq.gz')
 
-            if DATASET_HAS_SHORT_READS:
-                symlink_or_compress(sample.short_read_left_path,f'{identifier}/raw/short/{identifier}_R1.fastq.gz')
-                symlink_or_compress(sample.short_read_right_path,f'{identifier}/raw/short/{identifier}_R2.fastq.gz')
+        if DATASET_HAS_SHORT_READS:
+            symlink_or_compress(sample.short_read_left_path,f'{identifier}/raw/short/{identifier}_R1.fastq.gz')
+            symlink_or_compress(sample.short_read_right_path,f'{identifier}/raw/short/{identifier}_R2.fastq.gz')
 
 # Include various modules.
 include: './qc.smk'


### PR DESCRIPTION
I have merged all the current backlog of pull requests into develop_lee as they are piling up.

Features Added:

- Raise a value error when no contigs pass the coverage test in rule `split_circular_and_linear_contigs.` Fixes https://github.com/rotary-genomics/rotary/issues/199 where no circular or linear contigs lists are written, which causes a workflow error.
- Update the QC before-and-after report code to handle KBP (highly filtered reads) and GBP (many Illumina reads) values. These values commonly break the old version of the code. Convert results with these units to MBP - See https://github.com/rotary-genomics/rotary/pull/201 for details.
- In the rule `search_contig_start`, add the `-p meta` flag to run prodigal in meta mode. The prodigal doesn't scan the genome in this mode to build the gene-calling model. Instead, it predicts genes using prebuilt models, which is suitable for metagenomics. Prodigal requires at least 20K bases to make a model, which is larger than many circular plasmids. In some cases, Prodigal would fail when the only circular element is a small plasmid because the rest of the genome is fragmented and the plasmid is shorter than 20K bases. @jmtsuji Do you think running the `-p meta` flag should be sufficient if we are doing a start gene search? 
- Remove end_repair assemblies from assembly stats as they are most often identical to the flye assembly stats.
- Aggregate checkm stats from all samples into a single file for easier viewing.
- Aggregate gtdbtk reports from all samples into a single file for easier viewing.
- Aggregate coverage report from all samples into a single file for easier viewing.
- Change the top-level stats folder name to 'aggregate_stats' to indicate that this folder contains stats from multiple samples
- Add freebayes explicitly to the `pyploca.yml` install to prevent an install failure.
- Snakemake 8.6.0 introduced a bug that prevents the deletion of temp files created before a checkpoint, causing storage issues due to accumulating gigabytes of temp files, which I reported in snakemake/snakemake#2982. Downgrade to version 7 to temporarily fix this issue. Details: https://github.com/rotary-genomics/rotary/pull/216. I was originally going to go back to snakemake version 8.5.5 but I found that this version also causes some stability issues (I think it was before version 8's initial release), so I decided to downgrade to version 7. Details: https://github.com/rotary-genomics/rotary/pull/217
- Modify rule `set_up_sample_directories` so that each sample directory is generated dynamically and remove the sample tsv as input. This allows the sample TSV to be modified without causing the entire pipeline to be run all over again from scratch.
- Fixes a minor bug where aggregated CheckM2 and GTDB-Tk could not be turned off in the config file, because they were not specified as optional in rule annotation in annotations.smk. They are now specified as optional,