### PR TITLE
Fix snakemake version to be less than 8.6.0 to fix temp delete issue.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.11.*
   - pandas=1.5.*
-  - snakemake=8.*
+  - snakemake>=8,<8.6.0
   - mamba=1.5.*
   - wget=1.21.*
   - psutil=5.9.*

--- a/meta.yml
+++ b/meta.yml
@@ -12,7 +12,7 @@ requirements:
   run:
     - python=3.11.*
     - pandas=1.5.*
-    - snakemake=8.*
+    - snakemake>=8,<8.6.0
     - mamba=1.5.*
     - wget=1.21.*
     - psutil=5.9.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 dependencies = [
     "pandas ~=1.5",
-    "snakemake ~=8.0",
+    "snakemake >=8.0.0, <8.6.0",
     "psutil ~=5.9",
 ]
 


### PR DESCRIPTION
Snakemake 8.6.0 introduced a bug that prevented the deletion of temp files created before a checkpoint, even after a complete DAG execution. This bug was introduced when a pull request was merged into version 8.6.0 of Snakemake, which prevented some corner cases where temp files were deleted before a checkpoint even though they were needed later. However, this change prevents any temp files before a checkpoint from being deleted. After this bug was introduced, these temp files were not deleted, even at the end of the pipeline. We have many gigabytes of temp files in our pipeline before the checkpoint 'split_circular_and_linear_contigs' that need to be deleted; this leads to my server running out of storage room.  I provided a bug report to Snakemake here: https://github.com/snakemake/snakemake/issues/2982

As a temporary fix I am fixing the Snakemake version to be less than 8.6.0 but more than 8.0.0.