### PR TITLE
move setting up sample directories to use wild cards.

### DIFF
--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -46,8 +46,6 @@ rule all:
         "checkpoints/annotation"
 
 rule set_up_sample_directory:
-    input:
-        SAMPLE_TSV_PATH
     output:
         long_reads = "{sample}/raw/long/{sample}_long.fastq.gz",
         short_R1_reads = "{sample}/raw/short/{sample}_R1.fastq.gz" if DATASET_HAS_SHORT_READS else [],

--- a/rotary/rules/rotary.smk
+++ b/rotary/rules/rotary.smk
@@ -45,21 +45,21 @@ rule all:
         "checkpoints/circularize",
         "checkpoints/annotation"
 
-rule set_up_sample_directories:
+rule set_up_sample_directory:
     input:
         SAMPLE_TSV_PATH
     output:
-        long_reads = expand("{sample}/raw/long/{sample}_long.fastq.gz", sample=SAMPLE_NAMES),
-        short_R1_reads = expand("{sample}/raw/short/{sample}_R1.fastq.gz", sample=SAMPLE_NAMES) if DATASET_HAS_SHORT_READS else [],
-        short_R2_reads = expand("{sample}/raw/short/{sample}_R2.fastq.gz", sample=SAMPLE_NAMES) if DATASET_HAS_SHORT_READS else []
+        long_reads = "{sample}/raw/long/{sample}_long.fastq.gz",
+        short_R1_reads = "{sample}/raw/short/{sample}_R1.fastq.gz" if DATASET_HAS_SHORT_READS else [],
+        short_R2_reads = "{sample}/raw/short/{sample}_R2.fastq.gz" if DATASET_HAS_SHORT_READS else []
     run:
-        for sample in SAMPLES:
-            identifier = sample.identifier
-            symlink_or_compress(sample.long_read_path,f'{identifier}/raw/long/{identifier}_long.fastq.gz')
+        sample = SAMPLES[wildcards.sample]
+        identifier = sample.identifier
+        symlink_or_compress(sample.long_read_path,f'{identifier}/raw/long/{identifier}_long.fastq.gz')
 
-            if DATASET_HAS_SHORT_READS:
-                symlink_or_compress(sample.short_read_left_path,f'{identifier}/raw/short/{identifier}_R1.fastq.gz')
-                symlink_or_compress(sample.short_read_right_path,f'{identifier}/raw/short/{identifier}_R2.fastq.gz')
+        if DATASET_HAS_SHORT_READS:
+            symlink_or_compress(sample.short_read_left_path,f'{identifier}/raw/short/{identifier}_R1.fastq.gz')
+            symlink_or_compress(sample.short_read_right_path,f'{identifier}/raw/short/{identifier}_R2.fastq.gz')
 
 # Include various modules.
 include: './qc.smk'


### PR DESCRIPTION
Rather than making all the sample directories simultaneously, instead make them dynamically. Remove sample TSV as an input requirement so it can be modify to exclude samples without having to rerun the entire pipeline over again.