### PR TITLE
Rename aggregate stats

### DIFF
--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -282,7 +282,7 @@ rule aggregate_gtdbtk_reports:
     input:
         expand("{sample}/annotation/gtdbtk/{sample}_gtdbtk.summary.tsv", sample=SAMPLE_NAMES)
     output:
-        'stats/annotation/aggregate_gtdbtk_summary_report.tsv'
+        'aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv'
     benchmark:
         "benchmarks/annotation/aggregate_gtdbtk.benchmark.txt"
     run:
@@ -318,7 +318,7 @@ rule aggregate_checkm2_reports:
     input:
         expand("{sample}/annotation/checkm/{sample}_checkm_quality_report.tsv", sample=SAMPLE_NAMES)
     output:
-        'stats/annotation/aggregate_checkm_quality_report.tsv'
+        'aggregate_stats/annotation/aggregate_checkm_quality_report.tsv'
     benchmark:
         "benchmarks/annotation/aggregate_checkm.benchmark.txt"
     run:
@@ -435,7 +435,7 @@ rule summarize_annotation:
 rule annotation:
     input:
         summeries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
-        aggregate_checkm_report='stats/annotation/aggregate_checkm_quality_report.tsv',
-        aggregate_gtdbtk_report='stats/annotation/aggregate_gtdbtk_summary_report.tsv'
+        aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv',
+        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv'
     output:
         temp(touch("checkpoints/annotation"))

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -133,8 +133,8 @@ rule aggregate_assembly_stats_multiqc:
     input:
         expand("{sample}/assembly/stats/",sample=SAMPLE_NAMES)
     output:
-        multqc_report="stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        multqc_report_data="stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     conda:
         "../envs/qc.yaml"
     log:
@@ -142,7 +142,7 @@ rule aggregate_assembly_stats_multiqc:
     benchmark:
         "benchmarks/assembly/assembly_stats_multiqc.txt"
     params:
-        qc_stats_dir="stats/assembly/"
+        qc_stats_dir='aggregate_stats/assembly/"
     shell:
         """
         multiqc --outdir {params.qc_stats_dir} \
@@ -156,7 +156,7 @@ rule assembly:
     input:
         assembly_fasta = expand("{sample}/assembly/{sample}_assembly.fasta",sample=SAMPLE_NAMES),
         assembly_circular_info = expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES),
-        assembly_multqc_report="stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        assembly_multqc_report_data="stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        assembly_multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        assembly_multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     output:
         temp(touch("checkpoints/assembly"))

--- a/rotary/rules/assembly.smk
+++ b/rotary/rules/assembly.smk
@@ -133,8 +133,8 @@ rule aggregate_assembly_stats_multiqc:
     input:
         expand("{sample}/assembly/stats/",sample=SAMPLE_NAMES)
     output:
-        multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        multqc_report="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        multqc_report_data="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     conda:
         "../envs/qc.yaml"
     log:
@@ -142,7 +142,7 @@ rule aggregate_assembly_stats_multiqc:
     benchmark:
         "benchmarks/assembly/assembly_stats_multiqc.txt"
     params:
-        qc_stats_dir='aggregate_stats/assembly/"
+        qc_stats_dir="aggregate_stats/assembly/"
     shell:
         """
         multiqc --outdir {params.qc_stats_dir} \
@@ -156,7 +156,7 @@ rule assembly:
     input:
         assembly_fasta = expand("{sample}/assembly/{sample}_assembly.fasta",sample=SAMPLE_NAMES),
         assembly_circular_info = expand("{sample}/assembly/{sample}_circular_info.tsv", sample=SAMPLE_NAMES),
-        assembly_multqc_report='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
-        assembly_multqc_report_data='aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
+        assembly_multqc_report="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report.html",
+        assembly_multqc_report_data="aggregate_stats/assembly/all_samples_assembly_stats_multiqc_report_data.zip"
     output:
         temp(touch("checkpoints/assembly"))

--- a/rotary/rules/qc.smk
+++ b/rotary/rules/qc.smk
@@ -482,7 +482,7 @@ rule generate_long_aggregate_qc_stats:
     input:
         expand("{sample}/qc/qc_stats/long/{sample}_long_multiqc_report_data.zip", sample=SAMPLE_NAMES)
     output:
-        'stats/qc/before_and_after_qc_sequence_stats_long.tsv'
+        'aggregate_stats/qc/before_and_after_qc_sequence_stats_long.tsv'
     benchmark:
         "benchmarks/qc/qc_long_aggregate_stats.benchmark.txt"
     run:
@@ -495,8 +495,8 @@ rule generate_short_aggregate_qc_stats:
     input:
         expand("{sample}/qc/qc_stats/short/{sample}_short_multiqc_report_data.zip", sample=SAMPLE_NAMES)
     output:
-        left_qc_stats='stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv',
-        right_qc_stats='stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv'
+        left_qc_stats='aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv',
+        right_qc_stats='aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv'
     benchmark:
         "benchmarks/qc/qc_short_aggregate_stats.benchmark.txt"
     run:
@@ -515,9 +515,9 @@ rule qc_stats:
 
 rule aggregate_qc_stats:
     input:
-        left_short_qc_stats = 'stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv' if POLISH_WITH_SHORT_READS else [],
-        right_short_qc_stats = 'stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv' if POLISH_WITH_SHORT_READS else [],
-        long_qc_stats = 'stats/qc/before_and_after_qc_sequence_stats_long.tsv'
+        left_short_qc_stats = 'aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R1.tsv' if POLISH_WITH_SHORT_READS else [],
+        right_short_qc_stats = 'aggregate_stats/qc/before_and_after_qc_sequence_stats_short_R2.tsv' if POLISH_WITH_SHORT_READS else [],
+        long_qc_stats = 'aggregate_stats/qc/before_and_after_qc_sequence_stats_long.tsv'
     output:
         temp(touch("checkpoints/aggregate_qc_stats"))
 


### PR DESCRIPTION
- change the top-level stats folder name to 'aggregate_stats' to indicate that this folder contains stats from multiple samples