### PR TITLE
Coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ conda env create -n rotary --file=rotary/environment.yml
 
 conda activate rotary
 
-cd ../rotary
+cd rotary
 pip install --editable .
 
 # See command line options

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -335,7 +335,7 @@ if POLISH_WITH_SHORT_READS == True:
         output:
             mapping="{sample}/annotation/coverage/{sample}_short_read.bam" if KEEP_BAM_FILES else temp("{sample}/annotation/coverage/{sample}_short_read.bam"),
             index=temp("{sample}/annotation/coverage/{sample}_short_read.bam.bai"),
-            coverage="{sample}/annotation/coverage/{sample}_short_read_coverage.tsv",
+            coverage=temp("{sample}/annotation/coverage/{sample}_short_read_coverage_raw.tsv"),
             read_mapping_files= temp(multiext("{sample}/annotation/dfast/{sample}_genome.fna",
                 *READ_MAPPING_FILE_EXTENSIONS)) # Variable declared in polish.smk
         conda:
@@ -369,7 +369,7 @@ rule calculate_final_long_read_coverage:
     output:
         mapping="{sample}/annotation/coverage/{sample}_long_read.bam" if KEEP_BAM_FILES else temp("{sample}/annotation/coverage/{sample}_long_read.bam"),
         index=temp("{sample}/annotation/coverage/{sample}_long_read.bam.bai"),
-        coverage="{sample}/annotation/coverage/{sample}_long_read_coverage.tsv"
+        coverage=temp("{sample}/annotation/coverage/{sample}_long_read_coverage_raw.tsv")
     conda:
         "../envs/mapping.yaml"
     log:
@@ -391,6 +391,36 @@ rule calculate_final_long_read_coverage:
         samtools index -@ {threads} {output.mapping}
         samtools coverage {output.mapping} > {output.coverage}
         """
+
+
+rule reformat_final_read_coverage:
+    input:
+        "{sample}/annotation/coverage/{sample}_{long_or_short}_read_coverage_raw.tsv"
+    output:
+        "{sample}/annotation/coverage/{sample}_{long_or_short}_read_coverage.tsv"
+    params:
+        sample_id="{sample}",
+        read_type="{long_or_short}"
+    run:
+        read_coverage = pd.read_csv(input[0], sep='\t')\
+            .rename(columns={'#rname':'contig'})
+
+        read_coverage.insert(0, column='sample', value=params.sample_id)
+        read_coverage.insert(1, column='read_type', value=params.read_type)
+
+        read_coverage.to_csv(output[0], sep='\t', index=False)
+
+
+rule aggregate_final_read_coverage:
+    input:
+        expand("{sample}/annotation/coverage/{sample}_{long_or_short}_read_coverage.tsv", sample=SAMPLE_NAMES, long_or_short=['long','short']) \
+            if POLISH_WITH_SHORT_READS == True else expand("{sample}/annotation/coverage/{sample}_long_read_coverage.tsv", sample=SAMPLE_NAMES)
+    output:
+        'aggregate_stats/annotation/aggregate_read_coverage.tsv'
+    benchmark:
+        "benchmarks/annotation/aggregate_read_coverage.txt"
+    run:
+        combine_tabular_reports(input,output[0])
 
 
 rule symlink_logs:
@@ -436,6 +466,7 @@ rule annotation:
     input:
         summeries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
         aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv',
-        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv'
+        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv',
+        aggregate_final_read_coverage='aggregate_stats/annotation/aggregate_read_coverage.tsv'
     output:
         temp(touch("checkpoints/annotation"))

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -464,9 +464,9 @@ rule summarize_annotation:
 
 rule annotation:
     input:
-        summeries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
-        aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv',
-        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv',
-        aggregate_final_read_coverage='aggregate_stats/annotation/aggregate_read_coverage.tsv'
+        summaries=expand("{sample}/{sample}_annotation_summary.zip",sample=SAMPLE_NAMES),
+        aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv' if ANNOTATION_MAP.checkm2 else [],
+        aggregate_gtdbtk_report='aggregate_stats/annotation/aggregate_gtdbtk_summary_report.tsv' if ANNOTATION_MAP.gtdbtk else [],
+        aggregate_final_read_coverage='aggregate_stats/annotation/aggregate_read_coverage.tsv' if ANNOTATION_MAP.coverage else []
     output:
         temp(touch("checkpoints/annotation"))

--- a/rotary/rules/annotation.smk
+++ b/rotary/rules/annotation.smk
@@ -240,8 +240,8 @@ rule run_eggnog:
         """
         mkdir -p {output.outdir}/tmp
         emapper.py --cpu {threads} -i {input.protein} --itype proteins -m {params.search_tool} \
-          --sensmode {params.sensmode} --dbmem --output eggnog --output_dir {output.outdir} \
-          --temp_dir {output.outdir}/tmp --output {params.prefix} \
+          --sensmode {params.sensmode} --dbmem --output {params.prefix} --output_dir {output.outdir} \
+          --temp_dir {output.outdir}/tmp \
           --data_dir {params.db} --override > {log} 2>&1
         rm -r {output.outdir}/tmp
         """


### PR DESCRIPTION
Related to discussion in #157, this PR creates an aggregated coverage report for all genomes, in the following format:

```
sample  read_type  contig     startpos  endpos   numreads  covbases  coverage  meandepth  meanbaseq  meanmapq
S18     long       sequence1  1         2961164  70898     2961164   100.0     75.0783    22.1       59.7
S18     long       sequence2  1         2453422  52261     2453422   100.0     66.228     22.1       59.7
S18     long       sequence3  1         375275   11320     375275    100.0     92.3355    22.0       59.5
S18     long       sequence4  1         241390   5754      241390    100.0     73.334     22.0       59.5
S18     long       sequence5  1         54957    2233      54957     100.0     115.052    22.3       59.8
S18     short      sequence1  1         2961164  3284463   2961164   100.0     150.405    37.9       58.4
S18     short      sequence2  1         2453422  2338997   2453397   99.999    128.689    37.8       57.9
S18     short      sequence3  1         375275   499381    375275    100.0     179.596    37.8       55.3
S18     short      sequence4  1         241390   258687    241390    100.0     144.274    37.8       56.7
S18     short      sequence5  1         54957    84676     54957     100.0     207.594    37.8       58.9
```

This PR also fixes a minor bug where aggregated CheckM2 and GTDB-Tk could not be turned off in the config file, because they were not specified as optional in `rule annotation` in annotations.smk. They are now specified as optional, e.g.,

```
aggregate_checkm_report='aggregate_stats/annotation/aggregate_checkm_quality_report.tsv' if ANNOTATION_MAP.checkm2 else []
```

@LeeBergstrand Mind adding your review? Thanks!