### PR TITLE
Update install

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.11.*
   - pandas=1.5.*

--- a/rotary/envs/annotation_dfast.yaml
+++ b/rotary/envs/annotation_dfast.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - biopython=1.78
   - dfast=1.2.18 # remember to update VERSION_DFAST at top of snakefile when updating

--- a/rotary/envs/assembly_flye.yaml
+++ b/rotary/envs/assembly_flye.yaml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - flye=2.9

--- a/rotary/envs/checkm2.yaml
+++ b/rotary/envs/checkm2.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - checkm2=1.0.1
   - diamond=2.0.4

--- a/rotary/envs/circlator.yaml
+++ b/rotary/envs/circlator.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - circlator=1.5.5
   - flye=2.9

--- a/rotary/envs/download.yaml
+++ b/rotary/envs/download.yaml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - ncbi-datasets-cli=15.27
   - pigz=2.8

--- a/rotary/envs/eggnog.yaml
+++ b/rotary/envs/eggnog.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - eggnog-mapper=2.1.3 # Remember to update VERSION_EGGNOG in the snakefile if the eggnog DB version updates
   - diamond=2.0.6

--- a/rotary/envs/gtdbtk.yaml
+++ b/rotary/envs/gtdbtk.yaml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - gtdbtk=2.4.0 # Remember to update VERSION_GTDB in rotary/rules/annotation.smk if the GTDB version updates

--- a/rotary/envs/mapping.yaml
+++ b/rotary/envs/mapping.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.9.7
   - samtools=1.15

--- a/rotary/envs/medaka.yaml
+++ b/rotary/envs/medaka.yaml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - medaka=1.8.0

--- a/rotary/envs/polypolish.yaml
+++ b/rotary/envs/polypolish.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - polypolish=0.6.0
   - seqtk=1.3

--- a/rotary/envs/pypolca.yaml
+++ b/rotary/envs/pypolca.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - pypolca=0.3.1
   - freebayes=1.3.6

--- a/rotary/envs/qc.yaml
+++ b/rotary/envs/qc.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bbmap=38.18
   - pigz=2.8

--- a/rotary/envs/spokewrench.yaml
+++ b/rotary/envs/spokewrench.yaml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.9.*
   - pandas=1.4.*


### PR DESCRIPTION
Like mentioned in [BackBLAST PR 65](https://github.com/LeeBergstrand/BackBLAST_Reciprocal_BLAST/pull/65), this PR updates the install of rotary so that curated conda channels (like "defaults") are not required. This ensures that rotary can be used by those who do not have a paid conda license and are in an organization with >200 employees.

Full end-to-end test (with strict channel priorities) is working on Ubuntu 22.04.

@LeeBergstrand Mind providing your review? Thanks.